### PR TITLE
[v0.3] ATTENDANCE 추가 기능 구현

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceScheduler.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceScheduler.java
@@ -1,0 +1,19 @@
+package com.yanus.attendance.attendance.application;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AttendanceScheduler {
+
+    private final AttendanceService attendanceService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void autoCheckOut() {
+        LocalDate yesterday =LocalDate.now().minusDays(1);
+        attendanceService.autoCheckOut(yesterday);
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -1,12 +1,15 @@
 package com.yanus.attendance.attendance.application;
 
 import com.yanus.attendance.attendance.domain.Attendance;
+import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.team.domain.TeamName;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,6 +24,7 @@ public class AttendanceService {
 
     private final AttendanceRepository attendanceRepository;
     private final MemberRepository memberRepository;
+    private final AttendanceQueryRepository attendanceQueryRepository;
 
     public AttendanceResponse checkIn(Long memberId) {
         Member member = findMember(memberId);
@@ -49,6 +53,20 @@ public class AttendanceService {
         return attendanceRepository.findAllByWorkDate(date).stream()
                 .map(AttendanceResponse::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AttendanceResponse> getAttendancesByFilter(LocalDate date, TeamName teamName) {
+        return attendanceQueryRepository.findAllByFilter(date, teamName).stream()
+                .map(AttendanceResponse::from)
+                .toList();
+    }
+
+    public void autoCheckOut(LocalDate workDate) {
+        List<Attendance> workingAttendances =
+                attendanceRepository.findAllByWorkDateAndStatus(workDate, AttendanceStatus.WORKING);
+        LocalDateTime checkOutTime = workDate.atTime(23, 59, 59);
+        workingAttendances.forEach(attendance -> attendance.checkOut(checkOutTime));
     }
 
     private Member findMember(Long memberId) {

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
@@ -1,0 +1,48 @@
+package com.yanus.attendance.attendance.application;
+
+import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WorkScheduleService {
+
+    private final WorkScheduleRepository workScheduleRepository;
+    private final MemberRepository memberRepository;
+
+    public WorkScheduleResponse setWorkSchedule(Long memberId, WorkScheduleRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Optional<WorkSchedule> existing = workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, request.dayOfWeek());
+
+        if (existing.isPresent()) {
+            existing.get().update(request.startTime(), request.endTime());
+            return WorkScheduleResponse.from(existing.get());
+        }
+
+        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime());
+        workScheduleRepository.save(schedule);
+
+        return WorkScheduleResponse.from(schedule);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorkScheduleResponse> getMyWorkSchedules(Long memberId) {
+        return workScheduleRepository.findAllByMemberId(memberId).stream()
+                .map(WorkScheduleResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceQueryRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceQueryRepository.java
@@ -1,0 +1,9 @@
+package com.yanus.attendance.attendance.domain;
+
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AttendanceQueryRepository {
+    List<Attendance> findAllByFilter(LocalDate date, TeamName teamName);
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
@@ -13,4 +13,6 @@ public interface AttendanceRepository {
     List<Attendance> findAllByMemberId(Long memberId);
 
     List<Attendance> findAllByWorkDate(LocalDate workDate);
+
+    List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/WorkSchedule.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/WorkSchedule.java
@@ -1,0 +1,66 @@
+package com.yanus.attendance.attendance.domain;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "work_schedule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "work_schedule_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    public static WorkSchedule create(Member member, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+        validateTime(startTime, endTime);
+        WorkSchedule schedule = new WorkSchedule();
+        schedule.member = member;
+        schedule.dayOfWeek = dayOfWeek;
+        schedule.startTime = startTime;
+        schedule.endTime = endTime;
+        return schedule;
+    }
+
+    public void update(LocalTime startTime, LocalTime endTime) {
+        validateTime(startTime, endTime);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    private static void validateTime(LocalTime stateTime, LocalTime endTime) {
+        if (!endTime.isAfter(stateTime)) {
+            throw new BusinessException(ErrorCode.INVALID_WORK_SCHEDULE_TIME);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/WorkScheduleRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/WorkScheduleRepository.java
@@ -1,0 +1,14 @@
+package com.yanus.attendance.attendance.domain;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkScheduleRepository {
+
+    WorkSchedule save(WorkSchedule workSchedule);
+
+    Optional<WorkSchedule> findByMemberIdAndDayOfWeek(Long memberId, DayOfWeek dayOfWeek);
+
+    List<WorkSchedule> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -2,6 +2,7 @@ package com.yanus.attendance.attendance.infrastructure;
 
 import com.yanus.attendance.attendance.domain.Attendance;
 import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -32,5 +33,10 @@ public class AttendanceJpaRepository implements AttendanceRepository {
     @Override
     public List<Attendance> findAllByWorkDate(LocalDate workDate) {
         return repository.findAllByWorkDate(workDate);
+    }
+
+    @Override
+    public List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status) {
+        return repository.findAllByWorkDateAndStatus(workDate, status);
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yanus.attendance.attendance.domain.Attendance;
+import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.QAttendance;
+import com.yanus.attendance.member.domain.QMember;
+import com.yanus.attendance.team.domain.QTeam;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Attendance> findAllByFilter(LocalDate date, TeamName teamName) {
+        QAttendance attendance = QAttendance.attendance;
+        QMember member = QMember.member;
+        QTeam team = QTeam.team;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(attendance.workDate.eq(date));
+
+        if (teamName != null) {
+            builder.and(team.name.eq(teamName));
+        }
+
+        return queryFactory
+                .selectFrom(attendance)
+                .join(attendance.member, member).fetchJoin()
+                .join(member.team, team).fetchJoin()
+                .where(builder)
+                .fetch();
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.attendance.infrastructure;
 
 import com.yanus.attendance.attendance.domain.Attendance;
+import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +14,6 @@ public interface AttendanceSpringDataRepository extends JpaRepository<Attendance
     List<Attendance> findAllByMemberId(Long memberId);
 
     List<Attendance> findAllByWorkDate(LocalDate workDate);
+
+    List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
@@ -1,0 +1,31 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WorkScheduleJpaRepository implements WorkScheduleRepository {
+
+    private final WorkScheduleSpringDataRepository repository;
+
+    @Override
+    public WorkSchedule save(WorkSchedule workSchedule) {
+        return repository.save(workSchedule);
+    }
+
+    @Override
+    public Optional<WorkSchedule> findByMemberIdAndDayOfWeek(Long memberId, DayOfWeek dayOfWeek) {
+        return repository.findByMemberIdAndDayOfWeek(memberId, dayOfWeek);
+    }
+
+    @Override
+    public List<WorkSchedule> findAllByMemberId(Long memberId) {
+        return repository.findAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
@@ -1,0 +1,14 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.WorkSchedule;
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkScheduleSpringDataRepository extends JpaRepository<WorkSchedule, Long> {
+
+    Optional<WorkSchedule> findByMemberIdAndDayOfWeek(Long memberId, DayOfWeek dayOfWeek);
+
+    List<WorkSchedule> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.attendance.presentation;
 import com.yanus.attendance.attendance.application.AttendanceService;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.response.ApiResponse;
+import com.yanus.attendance.team.domain.TeamName;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,8 +42,10 @@ public class AttendanceController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<AttendanceResponse>>> getAttendancesByDate(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByDate(date)));
+    public ResponseEntity<ApiResponse<List<AttendanceResponse>>> getAttendancesByFilter(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) TeamName teamName
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleController.java
@@ -1,0 +1,37 @@
+package com.yanus.attendance.attendance.presentation;
+
+import com.yanus.attendance.attendance.application.WorkScheduleService;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/work-schedules")
+@RequiredArgsConstructor
+public class WorkScheduleController {
+
+    private final WorkScheduleService workScheduleService;
+
+    @PutMapping
+    public ResponseEntity<ApiResponse<WorkScheduleResponse>> setWorkSchedule(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody WorkScheduleRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleService.setWorkSchedule(memberId, request)));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<WorkScheduleResponse>>> getMyWorkSchedule(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleService.getMyWorkSchedules(memberId)));
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
@@ -1,0 +1,11 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record WorkScheduleRequest(
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
@@ -1,0 +1,21 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.WorkSchedule;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record WorkScheduleResponse(
+        Long id,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+    public static WorkScheduleResponse from(WorkSchedule schedule) {
+        return new WorkScheduleResponse(
+                schedule.getId(),
+                schedule.getDayOfWeek(),
+                schedule.getStartTime(),
+                schedule.getEndTime()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/global/config/QuerydslConfig.java
+++ b/src/main/java/com/yanus/attendance/global/config/QuerydslConfig.java
@@ -5,8 +5,10 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
+@EnableScheduling
 public class QuerydslConfig {
 
     @PersistenceContext

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     ALREADY_CHECKED_OUT(HttpStatus.BAD_REQUEST, "ATT_003", "이미 퇴근 처리되었습니다."),
     INVALID_CHECKOUT_TIME(HttpStatus.BAD_REQUEST, "ATT_004", "퇴근 시간은 출근 시간 이후여야 합니다."),
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATT_005", "출근 기록을 찾을 수 없습니다."),
+    INVALID_WORK_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "ATT_006", "종료 시간은 시작 시간 이후여야 합니다."),
 
     // Leave
     LEAVE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "LEAVE_REQUEST_NOT_FOUND", "존재하지 않는 휴가 신청입니다."),

--- a/src/main/resources/db/migration/V6__create_work_schedule.sql
+++ b/src/main/resources/db/migration/V6__create_work_schedule.sql
@@ -1,0 +1,8 @@
+CREATE TABLE work_schedule (
+                               work_schedule_id BIGSERIAL PRIMARY KEY,
+                               member_id        BIGINT NOT NULL REFERENCES member(member_id),
+                               day_of_week      VARCHAR(10) NOT NULL,
+                               start_time       TIME NOT NULL,
+                               end_time         TIME NOT NULL,
+                               UNIQUE (member_id, day_of_week)
+);

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
@@ -1,0 +1,25 @@
+package com.yanus.attendance.attendance;
+
+import com.yanus.attendance.attendance.domain.Attendance;
+import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.LocalDate;
+import java.util.List;
+
+public class FakeAttendanceQueryRepository implements AttendanceQueryRepository {
+
+    private final AttendanceRepository attendanceRepository;
+
+    public FakeAttendanceQueryRepository(AttendanceRepository attendanceRepository) {
+        this.attendanceRepository = attendanceRepository;
+    }
+
+    @Override
+
+    public List<Attendance> findAllByFilter(LocalDate date, TeamName teamName) {
+        return attendanceRepository.findAllByWorkDate(date).stream()
+                .filter(a -> teamName == null || a.getMember().getTeam().getName() == teamName)
+                .toList();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -2,6 +2,7 @@ package com.yanus.attendance.attendance;
 
 import com.yanus.attendance.attendance.domain.Attendance;
 import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,14 @@ public class FakeAttendanceRepository implements AttendanceRepository {
     public List<Attendance> findAllByWorkDate(LocalDate workDate) {
         return store.values().stream()
                 .filter(a -> a.getWorkDate().equals(workDate))
+                .toList();
+    }
+
+    @Override
+    public List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status) {
+        return store.values().stream()
+                .filter(a -> a.getWorkDate().equals(workDate))
+                .filter(a -> a.getStatus() == status)
                 .toList();
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
@@ -1,0 +1,40 @@
+package com.yanus.attendance.attendance;
+
+import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import java.time.DayOfWeek;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeWorkScheduleRepository implements WorkScheduleRepository {
+
+    private final Map<Long, WorkSchedule> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public WorkSchedule save(WorkSchedule workSchedule) {
+        if (workSchedule.getId() == null) {
+            ReflectionTestUtils.setField(workSchedule, "id", sequence++);
+        }
+        store.put(workSchedule.getId(), workSchedule);
+        return workSchedule;
+    }
+
+    @Override
+    public Optional<WorkSchedule> findByMemberIdAndDayOfWeek(Long memberId, DayOfWeek dayOfWeek) {
+        return store.values().stream()
+                .filter(s -> s.getMember().getId().equals(memberId))
+                .filter(s -> s.getDayOfWeek() == dayOfWeek)
+                .findFirst();
+    }
+
+    @Override
+    public List<WorkSchedule> findAllByMemberId(Long memberId) {
+        return store.values().stream()
+                .filter(s -> s.getMember().getId().equals(memberId))
+                .toList();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -3,7 +3,9 @@ package com.yanus.attendance.attendance.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
@@ -27,13 +29,15 @@ public class AttendanceServiceTest {
 
     private AttendanceService attendanceService;
     private AttendanceRepository attendanceRepository;
+    private AttendanceQueryRepository attendanceQueryRepository;
     private MemberRepository memberRepository;
 
     @BeforeEach
     void setUp() {
         attendanceRepository = new FakeAttendanceRepository();
         memberRepository = new FakeMemberRepository();
-        attendanceService = new AttendanceService(attendanceRepository, memberRepository);
+        AttendanceQueryRepository attendanceQueryRepository = new FakeAttendanceQueryRepository(attendanceRepository);
+        attendanceService = new AttendanceService(attendanceRepository, memberRepository, attendanceQueryRepository);
     }
 
     private Member createMember() {
@@ -109,5 +113,52 @@ public class AttendanceServiceTest {
 
         // then
         assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("팀 필터로 출퇴근 기록 조회")
+    void get_attendances_by_filter_with_team() {
+        // given
+        Member member = createMember();
+        LocalDate date = LocalDate.now();
+        attendanceService.checkIn(member.getId());
+
+        // when
+        List<AttendanceResponse> responses = attendanceService.getAttendancesByFilter(date, TeamName.BACKEND);
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("팀 필터 없이 전체 출퇴근 기록 조회")
+    void get_attendances_by_filter_without_team() {
+        // given
+        Member member = createMember();
+        LocalDate date = LocalDate.now();
+        attendanceService.checkIn(member.getId());
+
+        // when
+        List<AttendanceResponse> responses = attendanceService.getAttendancesByFilter(date, null);
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("자정 자동 퇴근 처리")
+    void auto_check_out() {
+        // given
+        Member member = createMember();
+        LocalDate date = LocalDate.now();
+        attendanceService.checkIn(member.getId());
+
+        // when
+        attendanceService.autoCheckOut(date);
+        List<AttendanceResponse> responses = attendanceService.getMyAttendances(member.getId());
+
+        // then
+        assertThat(responses.get(0).status()).isEqualTo(AttendanceStatus.LEFT);
+        assertThat(responses.get(0).checkOutTime()).isEqualTo(date.atTime(23, 59, 59));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -1,0 +1,92 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WorkScheduleServiceTest {
+
+    private WorkScheduleService workScheduleService;
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        WorkScheduleRepository workScheduleRepository = new FakeWorkScheduleRepository();
+        memberRepository = new FakeMemberRepository();
+        workScheduleService = new WorkScheduleService(workScheduleRepository, memberRepository);
+    }
+
+    private Member create() {
+        Team team = Team.create(TeamName.BACKEND);
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("정용태", "jyt6640@naver.com", "password123", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("근무 일정 등록")
+    void set_work_schedule() {
+        // given
+        Member member = create();
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
+
+        // then
+        assertThat(response.dayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+        assertThat(response.startTime()).isEqualTo(LocalTime.of(9, 0));
+        assertThat(response.endTime()).isEqualTo(LocalTime.of(18, 0));
+    }
+
+    @Test
+    @DisplayName("같은 요일 근무 일정 재등록 시 업데이트")
+    void update_work_schedule_when_same_day() {
+        // given
+        Member member = create();
+        workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0)));
+
+        // then
+        assertThat(response.startTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(response.endTime()).isEqualTo(LocalTime.of(19, 0));
+    }
+
+    @Test
+    @DisplayName("내 근무 일정 조회")
+    void get_my_work_schedules() {
+        // given
+        Member member = create();
+        workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+        workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        List<WorkScheduleResponse> responses = workScheduleService.getMyWorkSchedules(member.getId());
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
@@ -1,0 +1,68 @@
+package com.yanus.attendance.attendance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class WorkScheduleTest {
+
+    private Member createMember() {
+        Team team = Team.create(TeamName.BACKEND);
+        return Member.create("정용태", "jyt6640@naver.com", "password", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+    }
+
+    @Test
+    @DisplayName("근무 일정 생성")
+    void create_work_schedule() {
+        // given
+        Member member = createMember();
+        LocalTime start = LocalTime.of(9, 0);
+        LocalTime end = LocalTime.of(18, 0);
+
+        // when
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end);
+
+        // then
+        assertThat(schedule.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
+        assertThat(schedule.getStartTime()).isEqualTo(start);
+        assertThat(schedule.getEndTime()).isEqualTo(end);
+    }
+
+    @Test
+    @DisplayName("종료 시간이 시작 시간보다 이전이면 예외 발생")
+    void invalid_work_schedule_time() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() ->
+                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("종료 시간");
+    }
+
+    @Test
+    @DisplayName("근무 일정 수정")
+    void update_work_schedule() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(createMember(), DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        // when
+        schedule.update(LocalTime.of(10, 0), LocalTime.of(19, 0));
+
+        // then
+        assertThat(schedule.getStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(schedule.getEndTime()).isEqualTo(LocalTime.of(19, 0));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -10,6 +10,6 @@ spring.flyway.enabled=false
 # =====================
 # JWT (테스트용 고정값)
 # =====================
-jwt.secret=test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm
+jwt.secret=test-secret-key-must-be-at-least-32-characters-long
 jwt.access-expiration=3600000
 jwt.refresh-expiration=604800000


### PR DESCRIPTION
## 관련 이슈
closes #28
closes #29
closes #31

## 작업 내용

### ATTENDANCE
- 자정 자동 퇴근 처리 — 매일 00:00에 WORKING 상태 출근 기록 LEFT(23:59:59)로 자동 처리 (`@Scheduled`)
- 관리자 출퇴근 기록 조회 — 날짜 + 팀 필터 지원 (QueryDSL `BooleanBuilder`)
- 개인 근무 일정 설정 — 요일별 출퇴근 시간 upsert / 조회 (`work_schedule` 테이블, V6 migration)

### 기타
- CI JWT 기본값 설정

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
