### PR TITLE
[v1.0] CALENDAR 도메인 구현 및 v1.0 배포

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,21 @@
 ## 프로젝트 소개
 
 동아리/팀 단위로 사용할 수 있는 그룹웨어 백엔드 서버입니다.
-출퇴근 관리, 회원 관리, 휴가 신청 등 조직 운영에 필요한 기능을 제공합니다.
+출퇴근 관리, 회원 관리, 휴가 신청, 업무 관리, 캘린더 등 조직 운영에 필요한 기능을 제공합니다.
+
+---
+
+## 구현 현황
+
+| 도메인 | 기능 | 상태 |
+|--------|------|------|
+| **Team** | 팀 초기 데이터 구성 | ✅ 완료 |
+| **Auth** | 이메일 로그인, JWT 발급/재발급/로그아웃, 내 정보 조회 | ✅ 완료 |
+| **Member** | 회원 목록/상세 조회, 역할 변경, 활성화/비활성화, 프로필 수정 | ✅ 완료 |
+| **Attendance** | 출근/퇴근 체크인, 내 기록 조회, 관리자 조회(팀/날짜 필터), 자정 자동 퇴근, 개인 근무 일정 설정 | ✅ 완료 |
+| **Leave** | 휴가 신청, 본인/팀 목록 조회, 승인/반려 | ✅ 완료 |
+| **Task** | 개인/팀 Task 생성, 완료 토글, 수정/삭제, 목록 조회(날짜 범위 필터) | ✅ 완료 |
+| **Calendar** | 이벤트 생성/수정/삭제, 날짜 범위 조회, 생성자 기준 조회 | ✅ 완료 |
 
 ---
 
@@ -25,8 +39,9 @@
 | Docs | SpringDoc OpenAPI (Swagger UI) |
 | Test | JUnit5, AssertJ, Mockito, Testcontainers |
 | Build | Gradle |
-| CI | GitHub Actions |
+| CI/CD | GitHub Actions |
 | Container | Docker, Docker Compose |
+| Infra | 온프레미스 서버 (Nginx 리버스 프록시, systemd) |
 
 ---
 
@@ -48,17 +63,32 @@ presentation → application → domain ← infrastructure
 ```
 com.yanus.attendance
 ├── global/
-│   ├── config/          # Security, QueryDSL, Swagger
+│   ├── config/          # Security, QueryDSL, Swagger, Scheduling
 │   ├── exception/       # BusinessException, ErrorCode, GlobalExceptionHandler
 │   └── response/        # ApiResponse
 ├── team/
 ├── auth/
 ├── member/
-└── attendance/
-    ├── domain/           # Attendance, AttendanceStatus, AttendanceRepository
-    ├── application/      # AttendanceService
-    ├── infrastructure/   # AttendanceJpaRepository
-    └── presentation/     # AttendanceController, dto/
+├── attendance/
+│   ├── domain/           # Attendance, WorkSchedule, Repository 인터페이스
+│   ├── application/      # AttendanceService, WorkScheduleService, AttendanceScheduler
+│   ├── infrastructure/   # JPA 구현체, QueryDSL
+│   └── presentation/     # Controller, dto/
+├── leave/
+│   ├── domain/           # LeaveRequest, LeaveCategory, LeaveStatus
+│   ├── application/      # LeaveService
+│   ├── infrastructure/   # JPA 구현체
+│   └── presentation/     # Controller, dto/
+├── task/
+│   ├── domain/           # Task, TaskPriority, Repository 인터페이스
+│   ├── application/      # TaskService
+│   ├── infrastructure/   # JPA 구현체, QueryDSL
+│   └── presentation/     # Controller, dto/
+└── calendar/
+    ├── domain/           # CalendarEvent, Repository 인터페이스
+    ├── application/      # CalendarEventService
+    ├── infrastructure/   # JPA 구현체
+    └── presentation/     # Controller, dto/
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -923,3 +923,84 @@ No checks have been added
 - 이후 `CI / test` 형태의 체크를 required check로 연결할 수 있도록 정리
 
 ---
+
+# ATTENDANCE 도메인
+
+## 1. V5 SQL - BIGINT만 선언하면 PostgreSQL에서 자동 증가가 되지 않음
+
+**증상**
+```
+attendance_id가 null로 저장되거나 PK 자동 생성이 안 됨
+```
+
+**원인**
+`BIGINT PRIMARY KEY`로만 선언하면 PostgreSQL에서 자동 증가가 되지 않음.
+MySQL에서는 `AUTO_INCREMENT`를 별도로 붙이지만, PostgreSQL에서는 `BIGSERIAL`을 사용해야 함.
+
+**해결**
+```sql
+-- Before
+attendance_id BIGINT PRIMARY KEY
+
+-- After
+attendance_id BIGSERIAL PRIMARY KEY
+```
+
+---
+
+## 2. V5 SQL - 외래키 참조 컬럼 오류
+
+**증상**
+```
+ERROR: column "id" referenced in foreign key constraint does not exist
+```
+
+**원인**
+`member` 테이블의 PK 컬럼명은 `member_id`인데 `REFERENCES member(id)`로 잘못 참조함.
+
+**해결**
+```sql
+-- Before
+member_id BIGINT NOT NULL REFERENCES member(id)
+
+-- After
+member_id BIGINT NOT NULL REFERENCES member(member_id)
+```
+
+---
+
+## 3. 동일 경로에 두 메서드가 매핑되어 contextLoads() 실패
+
+**증상**
+```
+AttendanceApplicationTests > contextLoads() FAILED
+    Caused by: java.lang.IllegalStateException at AbstractHandlerMethodMapping.java:677
+```
+
+**원인**
+ATT-006 구현 시 `getAttendancesByFilter()` 메서드를 추가하면서 기존 `getAttendancesByDate()` 메서드를 삭제하지 않아 `GET /api/v1/attendances`에 두 메서드가 중복 매핑됨.
+
+**해결**
+`AttendanceController`에서 기존 `getAttendancesByDate()` 메서드 삭제.
+`AttendanceService`에서도 동일하게 삭제.
+
+---
+
+# TASK 도메인
+
+## 1. TaskSpringDataRepository에 JpaRepository 메서드 중복 선언
+
+**증상**
+컴파일은 되지만 불필요한 오버라이딩으로 코드가 지저분해짐.
+
+**원인**
+`JpaRepository<Task, Long>`을 상속하면 `save()`, `findById()`, `deleteById()`가 이미 제공되는데 인터페이스에 동일 메서드를 다시 선언함.
+
+**해결**
+`TaskSpringDataRepository`에서 중복 선언 제거. `JpaRepository` 상속만으로 충분.
+```java
+public interface TaskSpringDataRepository extends JpaRepository<Task, Long> {
+}
+```
+
+---

--- a/src/main/java/com/yanus/attendance/calendar/application/CalendarEventService.java
+++ b/src/main/java/com/yanus/attendance/calendar/application/CalendarEventService.java
@@ -1,0 +1,69 @@
+package com.yanus.attendance.calendar.application;
+
+import com.yanus.attendance.calendar.domain.CalendarEvent;
+import com.yanus.attendance.calendar.domain.CalendarEventRepository;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventCreateRequest;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CalendarEventService {
+
+    private final CalendarEventRepository calendarEventRepository;
+    private final MemberRepository memberRepository;
+
+    public CalendarEventResponse create(Long memberId, CalendarEventCreateRequest request) {
+        Member member = findMember(memberId);
+        CalendarEvent event = CalendarEvent.create(member, request.title(),
+                request.startDate(), request.startTime(),
+                request.endDate(), request.endTime());
+        calendarEventRepository.save(event);
+        return CalendarEventResponse.from(event);
+    }
+
+    public CalendarEventResponse update(Long eventId, CalendarEventCreateRequest request) {
+        CalendarEvent event = findEvent(eventId);
+        event.update(request.title(),
+                request.startDate(), request.startTime(),
+                request.endDate(), request.endTime());
+        return CalendarEventResponse.from(event);
+    }
+
+    public void delete(Long eventId) {
+        calendarEventRepository.deleteById(eventId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CalendarEventResponse> getByDateRange(LocalDate startDate, LocalDate endDate) {
+        return calendarEventRepository.findByDateRange(startDate, endDate).stream()
+                .map(CalendarEventResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CalendarEventResponse> getByCreatedBy(Long memberId) {
+        return calendarEventRepository.findByCreatedBy(memberId).stream()
+                .map(CalendarEventResponse::from)
+                .toList();
+    }
+
+    private CalendarEvent findEvent(Long id) {
+        return calendarEventRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CALENDAR_EVENT_NOT_FOUND));
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/yanus/attendance/calendar/domain/CalendarEvent.java
+++ b/src/main/java/com/yanus/attendance/calendar/domain/CalendarEvent.java
@@ -1,0 +1,87 @@
+package com.yanus.attendance.calendar.domain;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "calendar_event")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CalendarEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "calendar_event_id")
+    private Long id;
+
+    private String title;
+
+    private LocalDate startDate;
+
+    private LocalTime startTime;
+
+    private LocalDate endDate;
+
+    private LocalTime endTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private Member createdBy;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    public static CalendarEvent create(Member createdBy, String title,
+                                       LocalDate startDate, LocalTime startTime,
+                                       LocalDate endDate, LocalTime endTime) {
+        validateEndTime(startDate, startTime, endDate, endTime);
+        CalendarEvent event = new CalendarEvent();
+        event.createdBy = createdBy;
+        event.title = title;
+        event.startDate = startDate;
+        event.startTime = startTime;
+        event.endDate = endDate;
+        event.endTime = endTime;
+        event.createdAt = LocalDateTime.now();
+        event.updatedAt = LocalDateTime.now();
+        return event;
+    }
+
+    public void update(String title,
+                       LocalDate startDate, LocalTime startTime,
+                       LocalDate endDate, LocalTime endTime) {
+        validateEndTime(startDate, startTime, endDate, endTime);
+        this.title = title;
+        this.startDate = startDate;
+        this.startTime = startTime;
+        this.endDate = endDate;
+        this.endTime = endTime;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    private static void validateEndTime(LocalDate startDate, LocalTime startTime,
+                                        LocalDate endDate, LocalTime endTime) {
+        LocalDateTime start = LocalDateTime.of(startDate, startTime);
+        LocalDateTime end = LocalDateTime.of(endDate, endTime);
+        if (!end.isAfter(start)) {
+            throw new BusinessException(ErrorCode.INVALID_CALENDAR_END_TIME);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/calendar/domain/CalendarEventRepository.java
+++ b/src/main/java/com/yanus/attendance/calendar/domain/CalendarEventRepository.java
@@ -1,0 +1,18 @@
+package com.yanus.attendance.calendar.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CalendarEventRepository {
+
+    CalendarEvent save(CalendarEvent event);
+
+    Optional<CalendarEvent> findById(Long id);
+
+    void deleteById(Long id);
+
+    List<CalendarEvent> findByDateRange(LocalDate startDate, LocalDate endDate);
+
+    List<CalendarEvent> findByCreatedBy(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/calendar/infrastructure/CalendarEventJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/calendar/infrastructure/CalendarEventJpaRepository.java
@@ -1,0 +1,41 @@
+package com.yanus.attendance.calendar.infrastructure;
+
+import com.yanus.attendance.calendar.domain.CalendarEvent;
+import com.yanus.attendance.calendar.domain.CalendarEventRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CalendarEventJpaRepository implements CalendarEventRepository {
+
+    private final CalendarEventSpringDataRepository repository;
+
+    @Override
+    public CalendarEvent save(CalendarEvent event) {
+        return repository.save(event);
+    }
+
+    @Override
+    public Optional<CalendarEvent> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Override
+    public List<CalendarEvent> findByDateRange(LocalDate startDate, LocalDate endDate) {
+        return repository.findByDateRange(startDate, endDate);
+    }
+
+    @Override
+    public List<CalendarEvent> findByCreatedBy(Long memberId) {
+        return repository.findAllByCreatedById(memberId);
+    }
+}

--- a/src/main/java/com/yanus/attendance/calendar/infrastructure/CalendarEventSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/calendar/infrastructure/CalendarEventSpringDataRepository.java
@@ -1,0 +1,16 @@
+package com.yanus.attendance.calendar.infrastructure;
+
+import com.yanus.attendance.calendar.domain.CalendarEvent;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CalendarEventSpringDataRepository extends JpaRepository<CalendarEvent, Long> {
+
+    @Query("SELECT e FROM CalendarEvent e WHERE e.startDate >= :startDate AND e.endDate <= :endDate")
+    List<CalendarEvent> findByDateRange(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    List<CalendarEvent> findAllByCreatedById(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/calendar/presentation/CalendarEventController.java
+++ b/src/main/java/com/yanus/attendance/calendar/presentation/CalendarEventController.java
@@ -1,0 +1,62 @@
+package com.yanus.attendance.calendar.presentation;
+
+import com.yanus.attendance.calendar.application.CalendarEventService;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventCreateRequest;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import java.util.List;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class CalendarEventController {
+
+    private final CalendarEventService calendarEventService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CalendarEventResponse>> create(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody CalendarEventCreateRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(calendarEventService.create(memberId, request)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CalendarEventResponse>>> getByDateRange(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(calendarEventService.getByDateRange(startDate, endDate)));
+    }
+
+    @GetMapping("/me")
+    public  ResponseEntity<ApiResponse<List<CalendarEventResponse>>> getByCreatedBy(
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(calendarEventService.getByCreatedBy(memberId)));
+    }
+
+    @PutMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<CalendarEventResponse>> update(
+            @PathVariable Long eventId,
+            @RequestBody CalendarEventCreateRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(calendarEventService.update(eventId, request)));
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long eventId) {
+        calendarEventService.delete(eventId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/yanus/attendance/calendar/presentation/dto/CalendarEventCreateRequest.java
+++ b/src/main/java/com/yanus/attendance/calendar/presentation/dto/CalendarEventCreateRequest.java
@@ -1,0 +1,13 @@
+package com.yanus.attendance.calendar.presentation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CalendarEventCreateRequest(
+        String title,
+        LocalDate startDate,
+        LocalTime startTime,
+        LocalDate endDate,
+        LocalTime endTime
+) {
+}

--- a/src/main/java/com/yanus/attendance/calendar/presentation/dto/CalendarEventResponse.java
+++ b/src/main/java/com/yanus/attendance/calendar/presentation/dto/CalendarEventResponse.java
@@ -1,0 +1,29 @@
+package com.yanus.attendance.calendar.presentation.dto;
+
+import com.yanus.attendance.calendar.domain.CalendarEvent;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CalendarEventResponse(
+        Long id,
+        String title,
+        LocalDate startDate,
+        LocalTime startTime,
+        LocalDate endDate,
+        LocalTime endTime,
+        Long createdById,
+        String createdByName
+) {
+    public static CalendarEventResponse from(CalendarEvent event) {
+        return new CalendarEventResponse(
+                event.getId(),
+                event.getTitle(),
+                event.getStartDate(),
+                event.getStartTime(),
+                event.getEndDate(),
+                event.getEndTime(),
+                event.getCreatedBy().getId(),
+                event.getCreatedBy().getName()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -37,6 +37,11 @@ public enum ErrorCode {
     // Task
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "TASK_NOT_FOUND", "태스크를 찾을 수 없습니다."),
 
+    // Calendar
+    CALENDAR_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CALENDAR_EVENT_NOT_FOUND", "캘린더 이벤트를 찾을 수 없습니다."),
+    INVALID_CALENDAR_END_TIME(HttpStatus.BAD_REQUEST, "INVALID_CALENDAR_END_TIME", "종료 일시는 시작 일시 이후여야 합니다."),
+
+
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/db/migration/V9__create_calendar_event.sql
+++ b/src/main/resources/db/migration/V9__create_calendar_event.sql
@@ -1,0 +1,11 @@
+CREATE TABLE calendar_event (
+                                calendar_event_id BIGSERIAL PRIMARY KEY,
+                                title             VARCHAR(255) NOT NULL,
+                                start_date        DATE NOT NULL,
+                                start_time        TIME NOT NULL,
+                                end_date          DATE NOT NULL,
+                                end_time          TIME NOT NULL,
+                                created_by        BIGINT NOT NULL REFERENCES member(member_id),
+                                created_at        TIMESTAMP NOT NULL,
+                                updated_at        TIMESTAMP NOT NULL
+);

--- a/src/test/java/com/yanus/attendance/calendar/FakeCalendarEventRepository.java
+++ b/src/test/java/com/yanus/attendance/calendar/FakeCalendarEventRepository.java
@@ -1,0 +1,50 @@
+package com.yanus.attendance.calendar;
+
+import com.yanus.attendance.calendar.domain.CalendarEvent;
+import com.yanus.attendance.calendar.domain.CalendarEventRepository;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeCalendarEventRepository implements CalendarEventRepository {
+
+    private final Map<Long, CalendarEvent> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public CalendarEvent save(CalendarEvent event) {
+        if (event.getId() == null) {
+            ReflectionTestUtils.setField(event, "id", sequence++);
+        }
+        store.put(event.getId(), event);
+        return event;
+    }
+
+    @Override
+    public Optional<CalendarEvent> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
+
+    @Override
+    public List<CalendarEvent> findByDateRange(LocalDate startDate, LocalDate endDate) {
+        return store.values().stream()
+                .filter(e -> !e.getStartDate().isBefore(startDate))
+                .filter(e -> !e.getEndDate().isAfter(endDate))
+                .toList();
+    }
+
+    @Override
+    public List<CalendarEvent> findByCreatedBy(Long memberId) {
+        return store.values().stream()
+                .filter(e -> e.getCreatedBy().getId().equals(memberId))
+                .toList();
+    }
+}

--- a/src/test/java/com/yanus/attendance/calendar/application/CalendarEventServiceTest.java
+++ b/src/test/java/com/yanus/attendance/calendar/application/CalendarEventServiceTest.java
@@ -1,0 +1,137 @@
+package com.yanus.attendance.calendar.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.calendar.FakeCalendarEventRepository;
+import com.yanus.attendance.calendar.domain.CalendarEventRepository;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventCreateRequest;
+import com.yanus.attendance.calendar.presentation.dto.CalendarEventResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class CalendarEventServiceTest {
+
+    private CalendarEventService calendarEventService;
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        CalendarEventRepository calendarEventRepository = new FakeCalendarEventRepository();
+        memberRepository = new FakeMemberRepository();
+        calendarEventService = new CalendarEventService(calendarEventRepository, memberRepository);
+    }
+
+    private Member createMember() {
+        Team team = Team.create(TeamName.BACKEND);
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("정용태", "jyt6640@naver.com", "password123", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("캘린더 이벤트 생성")
+    void create_event() {
+        // given
+        Member member = createMember();
+        CalendarEventCreateRequest request = new CalendarEventCreateRequest(
+                "스프린트 회의",
+                LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0));
+
+        // when
+        CalendarEventResponse response = calendarEventService.create(member.getId(), request);
+
+        // then
+        assertThat(response.title()).isEqualTo("스프린트 회의");
+    }
+
+    @Test
+    @DisplayName("날짜 범위로 이벤트 조회")
+    void get_events_by_date_range() {
+        // given
+        Member member = createMember();
+        calendarEventService.create(member.getId(), new CalendarEventCreateRequest(
+                "이벤트1", LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0)));
+        calendarEventService.create(member.getId(), new CalendarEventCreateRequest(
+                "이벤트2", LocalDate.of(2026, 3, 25), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 25), LocalTime.of(10, 0)));
+
+        // when
+        List<CalendarEventResponse> responses = calendarEventService.getByDateRange(
+                LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("생성자 기준 이벤트 조회")
+    void get_events_by_created_by() {
+        // given
+        Member member = createMember();
+        calendarEventService.create(member.getId(), new CalendarEventCreateRequest(
+                "내 이벤트", LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0)));
+
+        // when
+        List<CalendarEventResponse> responses = calendarEventService.getByCreatedBy(member.getId());
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이벤트 수정")
+    void update_event() {
+        // given
+        Member member = createMember();
+        CalendarEventResponse created = calendarEventService.create(member.getId(),
+                new CalendarEventCreateRequest("원래 제목",
+                        LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                        LocalDate.of(2026, 3, 22), LocalTime.of(10, 0)));
+
+        // when
+        CalendarEventResponse response = calendarEventService.update(created.id(),
+                new CalendarEventCreateRequest("수정된 제목",
+                        LocalDate.of(2026, 3, 23), LocalTime.of(9, 0),
+                        LocalDate.of(2026, 3, 23), LocalTime.of(11, 0)));
+
+        // then
+        assertThat(response.title()).isEqualTo("수정된 제목");
+    }
+
+    @Test
+    @DisplayName("이벤트 삭제 후 조회 시 예외 발생")
+    void delete_event() {
+        // given
+        Member member = createMember();
+        CalendarEventResponse created = calendarEventService.create(member.getId(),
+                new CalendarEventCreateRequest("삭제할 이벤트",
+                        LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                        LocalDate.of(2026, 3, 22), LocalTime.of(10, 0)));
+
+        // when
+        calendarEventService.delete(created.id());
+
+        // then
+        assertThatThrownBy(() -> calendarEventService.update(created.id(),
+                new CalendarEventCreateRequest("수정", LocalDate.now(), LocalTime.of(9, 0),
+                        LocalDate.now(), LocalTime.of(10, 0))))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/yanus/attendance/calendar/domain/CalendarEventTest.java
+++ b/src/test/java/com/yanus/attendance/calendar/domain/CalendarEventTest.java
@@ -1,0 +1,71 @@
+package com.yanus.attendance.calendar.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamName;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CalendarEventTest {
+
+    private Member createMember() {
+        Team team = Team.create(TeamName.BACKEND);
+        return Member.create("정용태", "jyt6640@naver.com", "password", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+    }
+
+    @Test
+    @DisplayName("캘린더 이벤트 생성")
+    void create_calendar_event() {
+        // given
+        Member member = createMember();
+
+        // when
+        CalendarEvent event = CalendarEvent.create(member, "스프린트 회의",
+                LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0));
+
+        // then
+        assertThat(event.getTitle()).isEqualTo("스프린트 회의");
+        assertThat(event.getCreatedBy()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("종료 일시가 시작 일시보다 이전이면 예외 발생")
+    void invalid_end_time() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> CalendarEvent.create(member, "회의",
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(9, 0)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("종료");
+    }
+
+    @Test
+    @DisplayName("이벤트 수정")
+    void update_calendar_event() {
+        // given
+        Member member = createMember();
+        CalendarEvent event = CalendarEvent.create(member, "원래 제목",
+                LocalDate.of(2026, 3, 22), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 22), LocalTime.of(10, 0));
+
+        // when
+        event.update("수정된 제목",
+                LocalDate.of(2026, 3, 23), LocalTime.of(9, 0),
+                LocalDate.of(2026, 3, 23), LocalTime.of(11, 0));
+
+        // then
+        assertThat(event.getTitle()).isEqualTo("수정된 제목");
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #44
closes #45
closes #46
closes #47
closes #48

## 작업 내용
### CALENDAR
- 캘린더 이벤트 생성/수정/삭제
- 날짜 범위 조회 / 생성자 기준 조회
- V9 calendar_event 테이블 마이그레이션 추가

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
