### PR TITLE
[v2.2] 비활성화 멤버 로그인 차단

### DIFF
--- a/src/main/java/com/yanus/attendance/auth/application/AuthService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/AuthService.java
@@ -62,6 +62,10 @@ public class AuthService {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 
+        if (member.isInactive()) {
+            throw new BusinessException(ErrorCode.MEMBER_INACTIVE);
+        }
+
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
         String refreshTokenValue = jwtTokenProvider.createRefreshToken(member.getId());
 

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS", "이미 사용 중인 이메일입니다."),
+    MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER_INACTIVE", "비활성화된 계정입니다."),
 
     // Attendance
     ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "ALREADY_CHECKED_IN", "이미 출근 처리되었습니다."),

--- a/src/main/java/com/yanus/attendance/member/domain/Member.java
+++ b/src/main/java/com/yanus/attendance/member/domain/Member.java
@@ -85,4 +85,8 @@ public class Member {
             this.password = passwordEncoder.encode(encodedPassword);
         }
     }
+
+    public boolean isInactive() {
+        return this.status == MemberStatus.INACTIVE;
+    }
 }

--- a/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
@@ -12,10 +12,12 @@ import com.yanus.attendance.auth.presentation.dto.RegisterRequest;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import com.yanus.attendance.team.domain.TeamName;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -154,5 +156,24 @@ class AuthServiceTest {
 
         // then
         assertThat(refreshTokenRepository.findByToken(loginResponse.refreshToken())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("비활성화된 멤버가 로그인하면 예외 발생")
+    void inactive_member_loging_throw_error() {
+        // given
+        Team team = savedTeam();
+        authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+
+        // 비활성화 처리
+        Member member = memberRepository.findByEmail("hong@yanus.com").get();
+        member.deactivate();
+
+        LoginRequest request = new LoginRequest("hong@yanus.com", "password123");
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_INACTIVE);
     }
 }


### PR DESCRIPTION
## 변경 사항
- close #88
- INACTIVE 상태 멤버 로그인 시 `403 MEMBER_INACTIVE` 예외 반환
- `Member.isInactive()` 메서드 추가

## 보안
기존에 비활성화 처리 후에도 로그인이 가능했던 버그 수정
