### PR TITLE
[Fix] #91 - Team 엔티티 @Enumerated 어노테이션 제거

### DIFF
--- a/src/main/java/com/yanus/attendance/team/domain/Team.java
+++ b/src/main/java/com/yanus/attendance/team/domain/Team.java
@@ -2,8 +2,6 @@ package com.yanus.attendance.team.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,7 +22,6 @@ public class Team {
     @Column(name = "team_id")
     private Long id;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "name", nullable = false, unique = true, length = 50)
     private String name;
 


### PR DESCRIPTION
## 관련 이슈
- #91

## 원인
`TeamName` enum → `String` 변환 시 `@Enumerated(EnumType.STRING)` 어노테이션을 제거하지 않아
Hibernate `AnnotationException` 발생 → CI contextLoads() 실패

## 수정
`Team.java` 에서 `@Enumerated(EnumType.STRING)` 및 관련 import 제거