### PR TITLE
[Fix] #91 - V12 마이그레이션 FK 제약 조건 처리

### DIFF
--- a/src/main/resources/db/migration/V12__remove_default_teams.sql
+++ b/src/main/resources/db/migration/V12__remove_default_teams.sql
@@ -1,1 +1,4 @@
-DELETE FROM team;
+DELETE FROM team
+WHERE team_id NOT IN (
+    SELECT DISTINCT team_id FROM member WHERE team_id IS NOT NULL
+);


### PR DESCRIPTION
## 원인
`DELETE FROM team` 실행 시 `member` 테이블이 `team_id` FK로 참조 중인 팀이 있어 삭제 불가 → 502 에러

## 수정
멤버가 소속된 팀은 제외하고 참조 없는 팀만 삭제하도록 변경

```sql
DELETE FROM team
WHERE team_id NOT IN (
    SELECT DISTINCT team_id FROM member WHERE team_id IS NOT NULL
);
```