### PR TITLE
[v2.4] 멤버 팀 변경 API 추가

### DIFF
--- a/src/main/java/com/yanus/attendance/member/application/MemberService.java
+++ b/src/main/java/com/yanus/attendance/member/application/MemberService.java
@@ -9,6 +9,8 @@ import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +25,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberQueryRepository memberQueryRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TeamRepository teamRepository;
 
     public MemberResponse findById(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -63,5 +66,14 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         member.updateProfile(request.name(), request.password(), passwordEncoder);
+    }
+
+    @Transactional
+    public void changeTeam(Long memberId, Long TeamId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Team team = teamRepository.findById(TeamId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND));
+        member.changeTeam(team);
     }
 }

--- a/src/main/java/com/yanus/attendance/member/domain/Member.java
+++ b/src/main/java/com/yanus/attendance/member/domain/Member.java
@@ -89,4 +89,8 @@ public class Member {
     public boolean isInactive() {
         return this.status == MemberStatus.INACTIVE;
     }
+
+    public void changeTeam(Team team) {
+        this.team = team;
+    }
 }

--- a/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
@@ -6,6 +6,7 @@ import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TeamChangeRequest;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,14 @@ public class MemberController {
     @PatchMapping("/{memberId}/activate")
     public ResponseEntity<ApiResponse<Void>> activate(@PathVariable Long memberId) {
         memberService.activate(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PatchMapping("/{memberId}/team")
+    public ResponseEntity<ApiResponse<Void>> changeTeam(
+            @PathVariable Long memberId,
+            @RequestBody TeamChangeRequest request) {
+        memberService.changeTeam(memberId, request.teamId());
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/yanus/attendance/member/presentation/dto/TeamChangeRequest.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/dto/TeamChangeRequest.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.member.presentation.dto;
+
+public record TeamChangeRequest(
+        Long teamId
+) {
+}

--- a/src/test/java/com/yanus/attendance/member/application/MemberQueryServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberQueryServiceTest.java
@@ -8,7 +8,9 @@ import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
+import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
+import com.yanus.attendance.team.domain.TeamRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +20,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class MemberQueryServiceTest {
 
     private MemberService memberService;
+    private FakeTeamRepository teamRepository;
     private FakeMemberRepository memberRepository;
     private FakeMemberQueryRepository memberQueryRepository;
 
@@ -25,7 +28,7 @@ public class MemberQueryServiceTest {
     void setUp() {
         memberRepository = new FakeMemberRepository();
         memberQueryRepository = new FakeMemberQueryRepository();
-        memberService = new MemberService(memberRepository, memberQueryRepository, new BCryptPasswordEncoder());
+        memberService = new MemberService(memberRepository, memberQueryRepository, new BCryptPasswordEncoder(), teamRepository);
     }
 
     private Member saveMember(String teamName, MemberRole role) {

--- a/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
@@ -13,6 +13,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +25,13 @@ public class MemberServiceTest {
     private MemberService memberService;
     private FakeMemberQueryRepository memberQueryRepository;
     private FakeMemberRepository memberRepository;
+    private FakeTeamRepository teamRepository;
 
     @BeforeEach
     void setUp() {
         memberRepository = new FakeMemberRepository();
-        memberService = new MemberService(memberRepository, memberQueryRepository, new BCryptPasswordEncoder());
+        teamRepository = new FakeTeamRepository();
+        memberService = new MemberService(memberRepository, memberQueryRepository, new BCryptPasswordEncoder(), teamRepository);
     }
 
     private Member createMember(String email, MemberRole role) {
@@ -132,5 +135,48 @@ public class MemberServiceTest {
         // then
         assertThat(memberRepository.findById(member.getId()).get().getPassword())
                 .isNotEqualTo("encoded");
+    }
+
+    @Test
+    @DisplayName("멤버 팀 변경")
+    void change_member_team() {
+        // given
+        Team teamA = teamRepository.save(Team.create("1팀"));
+        Team teamB = teamRepository.save(Team.create("2팀"));
+        Member member = memberRepository.save(
+                Member.create("정용태", "jyt@naver.com", "encoded", MemberRole.MEMBER, MemberStatus.ACTIVE, teamA));
+
+        // when
+        memberService.changeTeam(member.getId(), teamB.getId());
+
+        // then
+        Member updated = memberRepository.findById(member.getId()).get();
+        assertThat(updated.getTeam().getId()).isEqualTo(teamB.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버 팀 변경 시 예외 발생")
+    void does_not_exist_member_chang_team_error() {
+        // given
+        Team team = teamRepository.save(Team.create("1팀"));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.changeTeam(999L, team.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 팀으로 변경 시 예외 발생")
+    void does_not_exist_team_error() {
+        // given
+        Team team = teamRepository.save(Team.create("1팀"));
+        Member member = memberRepository.save(
+                Member.create("정용태", "jyt@naver.com", "encoded", MemberRole.MEMBER, MemberStatus.ACTIVE, team));
+
+        // when & then`
+        assertThatThrownBy(() -> memberService.changeTeam(member.getId(), 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TEAM_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 관련 이슈
close #97

## 작업 내용
- `PATCH /api/v1/members/{memberId}/team` — 관리자가 멤버 소속 팀 변경

## 체크리스트
- [X] 테스트 작성 (Red)
- [X] 기능 구현 (Green)
- [X] 리팩터링 완료
- [X] 테스트 전체 통과
