### PR TITLE
[v2.5] 드라이브 전체 파일 목록 조회

### DIFF
--- a/src/main/java/com/yanus/attendance/drive/application/DriveFileService.java
+++ b/src/main/java/com/yanus/attendance/drive/application/DriveFileService.java
@@ -57,6 +57,13 @@ public class DriveFileService {
         driveFileRepository.deleteById(fileId);
     }
 
+    @Transactional(readOnly = true)
+    public List<DriveFileResponse> getAllFiles() {
+        return driveFileRepository.findAll().stream()
+                .map(DriveFileResponse::from)
+                .toList();
+    }
+
     private DriveFile findFile(Long fileId) {
         return driveFileRepository.findById(fileId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DRIVE_FILE_NOT_FOUND));

--- a/src/main/java/com/yanus/attendance/drive/domain/DriveFileRepository.java
+++ b/src/main/java/com/yanus/attendance/drive/domain/DriveFileRepository.java
@@ -12,4 +12,6 @@ public interface DriveFileRepository {
     List<DriveFile> findAllByUploadedById(Long uploadedById);
 
     void deleteById(Long id);
+
+    List<DriveFile> findAll();
 }

--- a/src/main/java/com/yanus/attendance/drive/infrastructure/DriveFileJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/drive/infrastructure/DriveFileJpaRepository.java
@@ -32,4 +32,9 @@ public class DriveFileJpaRepository implements DriveFileRepository {
     public void deleteById(Long id) {
         repository.deleteById(id);
     }
+
+    @Override
+    public List<DriveFile> findAll() {
+        return repository.findAll();
+    }
 }

--- a/src/main/java/com/yanus/attendance/drive/presentation/DriveFileController.java
+++ b/src/main/java/com/yanus/attendance/drive/presentation/DriveFileController.java
@@ -56,4 +56,9 @@ public class DriveFileController {
         driveFileService.delete(fileId);
         return ResponseEntity.ok(ApiResponse.success());
     }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DriveFileResponse>>> getAllFiles() {
+        return ResponseEntity.ok(ApiResponse.success(driveFileService.getAllFiles()));
+    }
 }

--- a/src/test/java/com/yanus/attendance/drive/FakeDriveFileRepository.java
+++ b/src/test/java/com/yanus/attendance/drive/FakeDriveFileRepository.java
@@ -2,6 +2,7 @@ package com.yanus.attendance.drive;
 
 import com.yanus.attendance.drive.domain.DriveFile;
 import com.yanus.attendance.drive.domain.DriveFileRepository;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,5 +38,10 @@ public class FakeDriveFileRepository implements DriveFileRepository {
     @Override
     public void deleteById(Long id) {
         store.remove(id);
+    }
+
+    @Override
+    public List<DriveFile> findAll() {
+        return new ArrayList<>(store.values());
     }
 }

--- a/src/test/java/com/yanus/attendance/drive/application/DriveFileServiceTest.java
+++ b/src/test/java/com/yanus/attendance/drive/application/DriveFileServiceTest.java
@@ -90,4 +90,21 @@ public class DriveFileServiceTest {
         assertThatThrownBy(() -> driveFileService.download(uploaded.id()))
                 .isInstanceOf(BusinessException.class);
     }
+
+    @Test
+    @DisplayName("전체 파일 목록 조회 테스트")
+    void get_all_files() {
+        // given
+        Member member = createMember();
+        MockMultipartFile file1 = new MockMultipartFile("file", "a.pdf", "application/pdf", "a".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("file", "b.png", "image/png", "b".getBytes());
+        driveFileService.upload(member.getId(), file1);
+        driveFileService.upload(member.getId(), file2);
+
+        // when
+        List<DriveFileResponse> responses = driveFileService.getAllFiles();
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- close #100

## 작업 내용
- `GET /api/v1/drive` — 본인 파일만 → 전체 파일 조회로 변경
- `DriveFileRepository.findAll()` 추가
- `DriveFileService.getAllFiles()` 추가


## 체크리스트
- [X] 테스트 작성 (Red)
- [X] 기능 구현 (Green)
- [X] 리팩터링 완료
- [X] 테스트 전체 통과