### PR TITLE
[Fix] #100 - 사용하지 않은 컨트롤러 삭제

### DIFF
--- a/src/main/java/com/yanus/attendance/drive/presentation/DriveFileController.java
+++ b/src/main/java/com/yanus/attendance/drive/presentation/DriveFileController.java
@@ -34,12 +34,6 @@ public class DriveFileController {
         return ResponseEntity.ok(ApiResponse.success(driveFileService.upload(memberId, file)));
     }
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<DriveFileResponse>>> getMyFiles(
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(ApiResponse.success(driveFileService.getMyFiles(memberId)));
-    }
-
     @GetMapping("/{fileId}/download")
     public ResponseEntity<byte[]> download(
             @PathVariable Long fileId) {


### PR DESCRIPTION
## 관련 이슈
- close #100

## 작업 내용
- `GET /api/v1/drive` — 본인 파일만 → 전체 파일 조회로 변경
- `DriveFileRepository.findAll()` 추가
- `DriveFileService.getAllFiles()` 추가


## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
