### PR TITLE
[v3.1] #125, #126 - 출근 IP 검증 및 출근 기록 삭제 추가

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -68,6 +68,27 @@ public class AttendanceService {
         workingAttendances.forEach(attendance -> attendance.checkOut(checkOutTime));
     }
 
+    public AttendanceResponse checkIn(Long memberId, String clientIp) {
+        validateAttendanceIp(clientIp);
+        Member member = findMember(memberId);
+        validateNotAlreadyCheckedIn(memberId);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now());
+        attendanceRepository.save(attendance);
+        return AttendanceResponse.from(attendance);
+    }
+
+    public void resetAttendance(Long memberId, LocalDate today) {
+        Attendance attendance = attendanceRepository.findByMemberIdAndWorkDate(memberId, today)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ATTENDANCE_NOT_FOUND));
+        attendanceRepository.delete(attendance);
+    }
+
+    private void validateAttendanceIp(String clientIp) {
+        if (!clientIp.startsWith("220.69")) {
+            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+        }
+    }
+
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
@@ -15,4 +15,6 @@ public interface AttendanceRepository {
     List<Attendance> findAllByWorkDate(LocalDate workDate);
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
+
+    void delete(Attendance attendance);
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -39,4 +39,9 @@ public class AttendanceJpaRepository implements AttendanceRepository {
     public List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status) {
         return repository.findAllByWorkDateAndStatus(workDate, status);
     }
+
+    @Override
+    public void delete(Attendance attendance) {
+        repository.delete(attendance);
+    }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation;
 
+import jakarta.servlet.http.HttpServletRequest;
 import com.yanus.attendance.attendance.application.AttendanceService;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.response.ApiResponse;
@@ -8,8 +9,10 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,8 +29,10 @@ public class AttendanceController {
 
     @PostMapping("/check-in")
     public ResponseEntity<ApiResponse<AttendanceResponse>> checkIn(
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(ApiResponse.success(attendanceService.checkIn(memberId)));
+            @AuthenticationPrincipal Long memberId,
+            HttpServletRequest request) {
+        String ip = extractClientIp(request);
+        return ResponseEntity.ok(ApiResponse.success(attendanceService.checkIn(memberId, ip)));
     }
 
     @PostMapping("/check-out")
@@ -44,9 +49,32 @@ public class AttendanceController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<AttendanceResponse>>> getAttendancesByFilter(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate date,
             @RequestParam(required = false) String teamName
     ) {
         return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> resetAttendance(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
+        LocalDate targetDate = null;
+        if (date != null) {
+            targetDate = date;
+        }
+        if (date == null) {
+            targetDate = LocalDate.now();
+        }
+        attendanceService.resetAttendance(memberId, targetDate);
+        return ResponseEntity.noContent().build();
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE_NOT_FOUND", "출근 기록을 찾을 수 없습니다."),
     INVALID_WORK_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_WORK_SCHEDULE_TIME", "종료 시간은 시작 시간 이후여야 합니다."),
     WORK_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORK_SCHEDULE_NOT_FOUND", "근무 일정을 찾을 수 없습니다."),
+    INVALID_ATTENDANCE_IP(HttpStatus.FORBIDDEN, "INVALID_ATTENDANCE_IP", "허용되지 않은 네트워크에서의 출근 요청입니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", "존재하지 않는 팀입니다."),

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -53,4 +53,9 @@ public class FakeAttendanceRepository implements AttendanceRepository {
                 .filter(a -> a.getStatus() == status)
                 .toList();
     }
+
+    @Override
+    public void delete(Attendance attendance) {
+        store.remove(attendance.getId());
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -10,6 +10,7 @@ import com.yanus.attendance.attendance.domain.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
@@ -159,5 +160,56 @@ public class AttendanceServiceTest {
         // then
         assertThat(responses.get(0).status()).isEqualTo(AttendanceStatus.LEFT);
         assertThat(responses.get(0).checkOutTime()).isEqualTo(date.atTime(23, 59, 59));
+    }
+
+    @Test
+    @DisplayName("허용된 IP로 체크인 성공")
+    void check_in_with_allowed_ip() {
+        // given
+        Member member = createMember();
+
+        // when
+        AttendanceResponse response = attendanceService.checkIn(member.getId(), "220.69.1.1");
+
+        // then
+        assertThat(response.status()).isEqualTo(AttendanceStatus.WORKING);
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 IP로 체크인 시 예외 발생")
+    void check_in_with_not_allowed_ip() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(member.getId(), "220.32.1.1"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ATTENDANCE_IP);
+    }
+
+    @Test
+    @DisplayName("오늘 출근 기록 초기화 성공")
+    void reset_attendance_success() {
+        // given
+        Member member = createMember();
+        attendanceService.checkIn(member.getId(), "220.69.1.1");
+
+        // when
+        attendanceService.resetAttendance(member.getId(), LocalDate.now());
+
+        // then
+        assertThat(attendanceService.getMyAttendances(member.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("출근 기록 없을 때 초기화 시 ATTENDANCE_NOT_FOUND 예외")
+    void reset_attendance_not_found_error() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.resetAttendance(member.getId(), LocalDate.now()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ATTENDANCE_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #125 
closes #126

## 작업 내용
- 헤더에서 사용자의 IP를 불러오는 기능 구현
- 해당 IP가 220.69 광역대 안에 있는지 확인하여 출근 가능 판단
- 당일 출근 기록 삭제 기능 추가

## 체크리스트
- [X] 테스트 작성 (Red)
- [X] 기능 구현 (Green)
- [X] 리팩터링 완료
- [X] 테스트 전체 통과
