### PR TITLE
[v3.2] 근무 일정 캘린더 고도화

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -1,9 +1,9 @@
 package com.yanus.attendance.attendance.application;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleEventService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleEventService.java
@@ -1,0 +1,69 @@
+package com.yanus.attendance.attendance.application;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WorkScheduleEventService {
+
+    private final WorkScheduleEventRepository workScheduleEventRepository;
+    private final MemberRepository memberRepository;
+
+    public WorkScheduleEventResponse createEvent(Long memberId, WorkScheduleEventRequest request) {
+        Member member = findMember(memberId);
+        validateNoDuplicate(memberId, request.date());
+        WorkScheduleEvent event = WorkScheduleEvent.create(member, request.date(), request.startTime(), request.endTime());
+        workScheduleEventRepository.save(event);
+        return WorkScheduleEventResponse.from(event);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorkScheduleEventResponse> getEvents(Long memberId, LocalDate startDate, LocalDate endDate) {
+        return workScheduleEventRepository.findAllByMemberIdAndDateBetween(memberId, startDate, endDate)
+                .stream().map(WorkScheduleEventResponse::from).toList();
+    }
+
+    public WorkScheduleEventResponse updateEvent(Long memberId, Long eventId, WorkScheduleEventRequest request) {
+        WorkScheduleEvent event = findEventAndValidateOwner(memberId, eventId);
+        event.update(request.startTime(), request.endTime());
+        return WorkScheduleEventResponse.from(event);
+    }
+
+    public void deleteEvent(Long memberId, Long eventId) {
+        WorkScheduleEvent event = findEventAndValidateOwner(memberId, eventId);
+        workScheduleEventRepository.delete(event);
+    }
+
+    private void validateNoDuplicate(Long memberId, LocalDate date) {
+        workScheduleEventRepository.findByMemberIdAndDate(memberId, date)
+                .ifPresent(e -> { throw new BusinessException(ErrorCode.WORK_SCHEDULE_EVENT_DUPLICATE); });
+    }
+
+    private WorkScheduleEvent findEventAndValidateOwner(Long memberId, Long eventId) {
+        WorkScheduleEvent event = workScheduleEventRepository.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
+        if (!event.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return event;
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.application;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
@@ -37,7 +37,7 @@ public class WorkScheduleService {
             return WorkScheduleResponse.from(existing.get());
         }
 
-        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime());
+        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime(), request.weekPattern());
         workScheduleRepository.save(schedule);
 
         return WorkScheduleResponse.from(schedule);
@@ -63,6 +63,12 @@ public class WorkScheduleService {
         return groupByMember(workScheduleRepository.findAll());
     }
 
+    public void deleteWorkSchedule(Long memberId, DayOfWeek dayOfWeek) {
+        workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, dayOfWeek)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
+        workScheduleRepository.deleteByMemberIdAndDayOfWeek(memberId, dayOfWeek);
+    }
+
     private List<MemberWorkScheduleResponse> groupByMember(List<WorkSchedule> schedules) {
         return schedules.stream()
                 .collect(Collectors.groupingBy(WorkSchedule::getMember))
@@ -76,12 +82,6 @@ public class WorkScheduleService {
                 .toList();
     }
 
-    public void deleteWorkSchedule(Long memberId, DayOfWeek dayOfWeek) {
-        workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, dayOfWeek)
-                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
-        workScheduleRepository.deleteByMemberIdAndDayOfWeek(memberId, dayOfWeek);
-    }
-
     private void validateAdmin(Long actorId) {
         Member actor = findMember(actorId);
         if (actor.getRole() != MemberRole.ADMIN) {
@@ -93,8 +93,7 @@ public class WorkScheduleService {
         if (actor.getRole() == MemberRole.ADMIN) {
             return;
         }
-        if (actor.getRole() == MemberRole.TEAM_LEAD
-                && actor.getTeam().getId().equals(teamId)) {
+        if (actor.getTeam().getId().equals(teamId)) {
             return;
         }
         throw new BusinessException(ErrorCode.FORBIDDEN);

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceStatus.java
@@ -1,5 +1,0 @@
-package com.yanus.attendance.attendance.domain;
-
-public enum AttendanceStatus {
-    WORKING, LEFT
-}

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/Attendance.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/Attendance.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceQueryRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceQueryRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceStatus.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+public enum AttendanceStatus {
+    WORKING, LEFT
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WeekPattern.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WeekPattern.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain.workschedule;
+
+public enum WeekPattern {
+    EVERY, FIRST, SECOND, THIRD, FOURTH, LAST
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
@@ -1,0 +1,72 @@
+package com.yanus.attendance.attendance.domain.workschedule;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "work_schedule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkSchedule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "work_schedule_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "week_pattern", nullable = false)
+    private WeekPattern weekPattern;
+
+    public static WorkSchedule create(Member member, DayOfWeek dayOfWeek,
+                                      LocalTime startTime, LocalTime endTime, WeekPattern weekPattern) {
+        validateTime(startTime, endTime);
+        WorkSchedule schedule = new WorkSchedule();
+        schedule.member = member;
+        schedule.dayOfWeek = dayOfWeek;
+        schedule.startTime = startTime;
+        schedule.endTime = endTime;
+        schedule.weekPattern = weekPattern != null ? weekPattern : WeekPattern.EVERY;
+        return schedule;
+    }
+
+    public void update(LocalTime startTime, LocalTime endTime) {
+        validateTime(startTime, endTime);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    private static void validateTime(LocalTime stateTime, LocalTime endTime) {
+        if (!endTime.isAfter(stateTime)) {
+            throw new BusinessException(ErrorCode.INVALID_WORK_SCHEDULE_TIME);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
@@ -1,12 +1,10 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.workschedule;
 
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,42 +12,42 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Entity
-@Table(name = "work_schedule")
+@Table(name = "work_schedule_event")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WorkSchedule {
+public class WorkScheduleEvent {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "work_schedule_id")
+    @Column(name = "work_schedule_event_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Enumerated(EnumType.STRING)
-    private DayOfWeek dayOfWeek;
+    private LocalDate date;
 
     private LocalTime startTime;
 
     private LocalTime endTime;
 
-    public static WorkSchedule create(Member member, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+    public static WorkScheduleEvent create(Member member, LocalDate date, LocalTime startTime, LocalTime endTime) {
         validateTime(startTime, endTime);
-        WorkSchedule schedule = new WorkSchedule();
-        schedule.member = member;
-        schedule.dayOfWeek = dayOfWeek;
-        schedule.startTime = startTime;
-        schedule.endTime = endTime;
-        return schedule;
+        WorkScheduleEvent event = new WorkScheduleEvent();
+        event.member = member;
+        event.date = date;
+        event.startTime = startTime;
+        event.endTime = endTime;
+        return event;
     }
 
     public void update(LocalTime startTime, LocalTime endTime) {
@@ -58,8 +56,8 @@ public class WorkSchedule {
         this.endTime = endTime;
     }
 
-    private static void validateTime(LocalTime stateTime, LocalTime endTime) {
-        if (!endTime.isAfter(stateTime)) {
+    private static void validateTime(LocalTime startTime, LocalTime endTime) {
+        if (!endTime.isAfter(startTime)) {
             throw new BusinessException(ErrorCode.INVALID_WORK_SCHEDULE_TIME);
         }
     }

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
@@ -1,0 +1,18 @@
+package com.yanus.attendance.attendance.domain.workschedule;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkScheduleEventRepository {
+
+    WorkScheduleEvent save(WorkScheduleEvent event);
+
+    Optional<WorkScheduleEvent> findById(Long id);
+
+    Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date);
+
+    List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    void delete(WorkScheduleEvent event);
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.workschedule;
 
 import java.time.DayOfWeek;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
@@ -2,9 +2,9 @@ package com.yanus.attendance.attendance.infrastructure;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.QAttendance;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.QAttendance;
 import com.yanus.attendance.member.domain.QMember;
 import com.yanus.attendance.team.domain.QTeam;
 import java.time.LocalDate;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/JpaWorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/JpaWorkScheduleEventRepository.java
@@ -1,0 +1,37 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaWorkScheduleEventRepository implements WorkScheduleEventRepository {
+
+    private final WorkScheduleEventSpringDataRepository repository;
+
+    @Override
+    public WorkScheduleEvent save(WorkScheduleEvent event) { return repository.save(event); }
+
+    @Override
+    public Optional<WorkScheduleEvent> findById(Long id) { return repository.findById(id); }
+
+    @Override
+    public Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date) {
+        return repository.findByMemberIdAndDate(memberId, date);
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return repository.findAllByMemberIdAndDateBetween(memberId, start, end);
+    }
+
+    @Override
+    public void delete(WorkScheduleEvent event) {
+        repository.delete(event);
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleEventSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleEventSpringDataRepository.java
@@ -1,0 +1,15 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkScheduleEventSpringDataRepository extends JpaRepository<WorkScheduleEvent, Long> {
+
+    Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date);
+
+    List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
+}
+

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
@@ -1,6 +1,6 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
@@ -1,0 +1,63 @@
+package com.yanus.attendance.attendance.presentation;
+
+import com.yanus.attendance.attendance.application.WorkScheduleEventService;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "닐찌뱔 근무 일정", description = "특정 날짜 근무 일정 CRUD")
+@RestController
+@RequestMapping("/api/v1/work-schedule-events")
+@RequiredArgsConstructor
+public class WorkScheduleEventController {
+
+    private final WorkScheduleEventService workScheduleEventService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<WorkScheduleEventResponse>> createEvent(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody WorkScheduleEventRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.createEvent(memberId, request)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<WorkScheduleEventResponse>>> getEvents(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.getEvents(memberId, startDate, endDate)));
+    }
+
+    @PutMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<WorkScheduleEventResponse>> updateEvent(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long eventId,
+            @RequestBody WorkScheduleEventRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.updateEvent(memberId, eventId, request)));
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<Void> deleteEvent(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long eventId) {
+        workScheduleEventService.deleteEvent(memberId, eventId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceResponse.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventRequest.java
@@ -1,0 +1,11 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleEventRequest(
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventResponse.java
@@ -1,0 +1,27 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleEventResponse(
+        Long id,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        Long memberId,
+        String memberName,
+        String teamName
+) {
+    public static WorkScheduleEventResponse from(WorkScheduleEvent event) {
+        return new WorkScheduleEventResponse(
+                event.getId(),
+                event.getDate(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getMember().getId(),
+                event.getMember().getName(),
+                event.getMember().getTeam().getName()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
@@ -1,11 +1,13 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
 public record WorkScheduleRequest(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
-        LocalTime endTime
+        LocalTime endTime,
+        WeekPattern weekPattern
 ) {
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
@@ -8,14 +9,16 @@ public record WorkScheduleResponse(
         Long id,
         DayOfWeek dayOfWeek,
         LocalTime startTime,
-        LocalTime endTime
+        LocalTime endTime,
+        WeekPattern weekPattern
 ) {
     public static WorkScheduleResponse from(WorkSchedule schedule) {
         return new WorkScheduleResponse(
                 schedule.getId(),
                 schedule.getDayOfWeek(),
                 schedule.getStartTime(),
-                schedule.getEndTime()
+                schedule.getEndTime(),
+                schedule.getWeekPattern()
         );
     }
 }

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_WORK_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_WORK_SCHEDULE_TIME", "종료 시간은 시작 시간 이후여야 합니다."),
     WORK_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORK_SCHEDULE_NOT_FOUND", "근무 일정을 찾을 수 없습니다."),
     INVALID_ATTENDANCE_IP(HttpStatus.FORBIDDEN, "INVALID_ATTENDANCE_IP", "허용되지 않은 네트워크에서의 출근 요청입니다."),
+    WORK_SCHEDULE_EVENT_DUPLICATE(HttpStatus.CONFLICT, "WORK_SCHEDULE_EVENT_DUPLICATE", "해당 날짜에 이미 근무 일정이 존재합니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", "존재하지 않는 팀입니다."),

--- a/src/main/resources/db/migration/V16__add_work_schedule_week_pattern.sql
+++ b/src/main/resources/db/migration/V16__add_work_schedule_week_pattern.sql
@@ -1,0 +1,2 @@
+ALTER TABLE work_schedule
+    ADD COLUMN week_pattern VARCHAR(20) NOT NULL DEFAULT 'EVERY';

--- a/src/main/resources/db/migration/V17__create_work_schedule_event.sql
+++ b/src/main/resources/db/migration/V17__create_work_schedule_event.sql
@@ -1,0 +1,10 @@
+CREATE TABLE work_schedule_event (
+                                     work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                                     member_id   BIGINT    NOT NULL,
+                                     date        DATE      NOT NULL,
+                                     start_time  TIME      NOT NULL,
+                                     end_time    TIME      NOT NULL,
+                                     created_at  TIMESTAMP NOT NULL,
+                                     FOREIGN KEY (member_id) REFERENCES member(member_id),
+                                     UNIQUE (member_id, date)
+);

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
@@ -1,0 +1,49 @@
+package com.yanus.attendance.attendance;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeWorkScheduleEventRepository implements WorkScheduleEventRepository {
+
+    private final Map<Long, WorkScheduleEvent> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public WorkScheduleEvent save(WorkScheduleEvent event) {
+        if (event.getId() == null) ReflectionTestUtils.setField(event, "id", sequence++);
+        store.put(event.getId(), event);
+        return event;
+    }
+
+    @Override
+    public Optional<WorkScheduleEvent> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getId().equals(memberId) && e.getDate().equals(date))
+                .findFirst();
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getId().equals(memberId))
+                .filter(e -> !e.getDate().isBefore(start) && !e.getDate().isAfter(end))
+                .toList();
+    }
+
+    @Override
+    public void delete(WorkScheduleEvent event) {
+        store.remove(event.getId());
+    }
+}
+

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import java.time.DayOfWeek;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
@@ -1,0 +1,125 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.attendance.FakeWorkScheduleEventRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WorkScheduleEventServiceTest {
+
+    private WorkScheduleEventService workScheduleEventService;
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = new FakeMemberRepository();
+        workScheduleEventService = new WorkScheduleEventService(new FakeWorkScheduleEventRepository(), memberRepository);
+    }
+
+    private Member createMember() {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("테스터", "test@test.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("날짜별 근무 일정 생성 성공")
+    void create_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventRequest request = new WorkScheduleEventRequest(
+                LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        // when
+        WorkScheduleEventResponse response = workScheduleEventService.createEvent(member.getId(), request);
+
+        // then
+        assertThat(response.date()).isEqualTo(LocalDate.of(2026, 3, 30));
+        assertThat(response.startTime()).isEqualTo(LocalTime.of(9, 0));
+    }
+
+    @Test
+    @DisplayName("같은 날짜 중복 일정 생성 시 예외")
+    void create_duplicate_event_error() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventRequest request = new WorkScheduleEventRequest(
+                LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0));
+        workScheduleEventService.createEvent(member.getId(), request);
+
+        // when & then
+        assertThatThrownBy(() -> workScheduleEventService.createEvent(member.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.WORK_SCHEDULE_EVENT_DUPLICATE);
+    }
+
+    @Test
+    @DisplayName("기간 내 날짜별 일정 조회")
+    void get_events_by_period() {
+        // given
+        Member member = createMember();
+        workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 10), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+        workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 20), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getEvents(
+                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("날짜별 일정 수정 성공")
+    void update_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventResponse created = workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        WorkScheduleEventResponse updated = workScheduleEventService.updateEvent(
+                member.getId(), created.id(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(10, 0), LocalTime.of(19, 0)));
+
+        // then
+        assertThat(updated.startTime()).isEqualTo(LocalTime.of(10, 0));
+    }
+
+    @Test
+    @DisplayName("날짜별 일정 삭제 성공")
+    void delete_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventResponse created = workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        workScheduleEventService.deleteEvent(member.getId(), created.id());
+
+        // then
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getEvents(
+                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+        assertThat(responses).isEmpty();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -4,7 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
@@ -53,7 +54,8 @@ public class WorkScheduleServiceTest {
     void set_work_schedule() {
         // given
         Member member = create();
-        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0));
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0),
+                WeekPattern.EVERY);
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
@@ -70,11 +72,11 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // then
         assertThat(response.startTime()).isEqualTo(LocalTime.of(10, 0));
@@ -87,9 +89,9 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.THURSDAY, LocalTime.of(9, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // when
         List<WorkScheduleResponse> responses = workScheduleService.getMyWorkSchedules(member.getId());
@@ -104,7 +106,7 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         workScheduleService.deleteWorkSchedule(member.getId(), DayOfWeek.MONDAY);
@@ -134,9 +136,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, member1.getTeam()));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.TUESDAY, LocalTime.of(10, 0), LocalTime.of(19, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -157,9 +159,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team2));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.WEDNESDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(member1.getId());
@@ -186,7 +188,7 @@ public class WorkScheduleServiceTest {
         // given
         Member admin = createMember("1팀", MemberRole.ADMIN);
         workScheduleService.setWorkSchedule(admin.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(admin.getId());
@@ -201,7 +203,7 @@ public class WorkScheduleServiceTest {
         // given
         Member teamLead = createMember("1팀", MemberRole.TEAM_LEAD);
         workScheduleService.setWorkSchedule(teamLead.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -225,13 +227,58 @@ public class WorkScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("MEMBER가 팀 근무 일정 조회 시 예외 발생")
-    void member_get_team_work_schedules_forbidden() {
+    @DisplayName("weekPattern FIRST로 등록 후 조회 시 FIRST 반환")
+    void set_work_schedule_with_week_pattern() {
+        // given
+        Member member = create();
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.FIRST);
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
+
+        // then
+        assertThat(response.weekPattern()).isEqualTo(WeekPattern.FIRST);
+    }
+
+    @Test
+    @DisplayName("weekPattern null로 등록 시 기본값 EVERY")
+    void set_work_schedule_default_week_pattern() {
+        // given
+        Member member = create();
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), null);
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
+
+        // then
+        assertThat(response.weekPattern()).isEqualTo(WeekPattern.EVERY);
+    }
+
+    @Test
+    @DisplayName("같은 팀 MEMBER가 팀 근무 일정 조회 성공")
+    void member_get_own_team_work_schedules_success() {
         // given
         Member member = createMember("1팀", MemberRole.MEMBER);
+        workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+
+        // when
+        List<MemberWorkScheduleResponse> responses =
+                workScheduleService.getTeamWorkSchedules(member.getId(), member.getTeam().getId());
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("다른 팀 MEMBER가 팀 근무 일정 조회 시 FORBIDDEN")
+    void member_get_other_team_work_schedules_forbidden() {
+        // given
+        Member member = createMember("1팀", MemberRole.MEMBER);
+        Member otherMember = createMember("2팀", MemberRole.MEMBER);
 
         // when & then
-        assertThatThrownBy(() -> workScheduleService.getTeamWorkSchedules(member.getId(), member.getTeam().getId()))
+        assertThatThrownBy(() -> workScheduleService.getTeamWorkSchedules(member.getId(), otherMember.getTeam().getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
     }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceTest.java
@@ -3,6 +3,8 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;

--- a/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;
@@ -29,7 +30,7 @@ public class WorkScheduleTest {
         LocalTime end = LocalTime.of(18, 0);
 
         // when
-        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end, null);
 
         // then
         assertThat(schedule.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
@@ -45,7 +46,7 @@ public class WorkScheduleTest {
 
         // when & then
         assertThatThrownBy(() ->
-                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0)))
+                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0), null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("종료 시간");
     }
@@ -55,7 +56,7 @@ public class WorkScheduleTest {
     void update_work_schedule() {
         // given
         WorkSchedule schedule = WorkSchedule.create(createMember(), DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0));
+                LocalTime.of(9, 0), LocalTime.of(18, 0), null);
 
         // when
         schedule.update(LocalTime.of(10, 0), LocalTime.of(19, 0));


### PR DESCRIPTION
## 관련 이슈
closes #129
closes #130
closes #131

## 작업 내용
- WeekPattern 서버 저장 — EVERY/FIRST/SECOND/THIRD/FOURTH/LAST
- 팀 근무 일정 조회 권한 확대 — 같은 팀 MEMBER도 조회 가능
- WorkScheduleEvent 도메인 추가 — 날짜별 예외 근무 일정 CRUD
- V16 마이그레이션: work_schedule.week_pattern 컬럼 추가
- V17 마이그레이션: work_schedule_event 테이블 생성

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
