### PR TITLE
[v3.3] #134, #135 - 출근 범위 조회 및 월별 지각 정산 기능 구현 

### DIFF
--- a/docs/troubleshooting/attendance.md
+++ b/docs/troubleshooting/attendance.md
@@ -43,7 +43,74 @@ member_id BIGINT NOT NULL REFERENCES member(member_id)
 
 ---
 
-### 3. 동일 경로에 두 메서드가 매핑되어 contextLoads() 실패
+### 3. V15 audit_log 마이그레이션 AUTO_INCREMENT 문법 오류 → 502
+
+**증상**
+```
+FlywayMigrateException: Script V15__create_audit_log.sql failed
+ERROR: syntax error at or near "AUTO_INCREMENT"
+```
+서버가 기동되지 않아 모든 API 502 응답.
+
+**원인**
+`AUTO_INCREMENT`는 MySQL 문법. PostgreSQL에서는 사용 불가.
+
+**해결**
+```sql
+-- Before
+audit_log_id BIGINT AUTO_INCREMENT PRIMARY KEY
+
+-- After
+audit_log_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+```
+
+---
+
+### 4. 로컬 신규 DB 세팅 시 회원가입 불가 — 닭이냐 달걀이냐
+
+**증상**
+회원가입 요청 시 `NOT_FOUND` 응답. API가 아무것도 안 되는 것처럼 보임.
+
+**원인**
+V12 마이그레이션에서 기본 팀 데이터를 전부 삭제함.
+팀이 없으면 회원가입 불가 → 유저가 없으면 팀 생성 API(ADMIN 전용) 호출 불가.
+
+**해결**
+Docker로 직접 초기 데이터 INSERT.
+```bash
+docker exec -i yanus-postgres psql -U yanus -d yanus -c "
+INSERT INTO team (name, created_at) VALUES ('개발팀', NOW()), ('신입', NOW()) ON CONFLICT (name) DO NOTHING;
+INSERT INTO member (name, email, password, role, team_id, status, created_at)
+SELECT '관리자', 'admin@test.com',
+'\$2a\$10\$Wb1BjoFhUBjxDHyGv94MTOtVmKJ2tjQPUy5i19qe/Tbi3QJ8s4eBS',
+'ADMIN', team_id, 'ACTIVE', NOW()
+FROM team WHERE name = '개발팀' ON CONFLICT (email) DO NOTHING;
+"
+```
+또는 `data.sql` + `application-local.properties`에 `spring.sql.init.mode=always` / `spring.jpa.defer-datasource-initialization=true` 설정.
+
+---
+
+### 5. 로컬에서 체크인 시 INVALID_ATTENDANCE_IP (403)
+
+**증상**
+로컬에서 체크인 API 호출 시 `INVALID_ATTENDANCE_IP` 403 응답.
+
+**원인**
+체크인은 `220.69` 대역 IP만 허용. 로컬 요청은 `127.0.0.1`로 들어와 차단됨.
+
+**해결**
+`X-Forwarded-For` 헤더로 허용 IP를 흉내내어 테스트.
+```bash
+curl -X POST http://localhost:8080/api/v1/attendances/check-in \
+  -H "Authorization: Bearer {토큰}" \
+  -H "X-Forwarded-For: 220.69.1.1"
+```
+Swagger UI는 임의 헤더 추가 불가 → curl 사용 필요.
+
+---
+
+### 6. 동일 경로에 두 메서드가 매핑되어 contextLoads() 실패
 
 **증상**
 ```

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -4,11 +4,13 @@ import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -83,15 +85,47 @@ public class AttendanceService {
         attendanceRepository.delete(attendance);
     }
 
-    private void validateAttendanceIp(String clientIp) {
-        if (!clientIp.startsWith("220.69")) {
-            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+    @Transactional(readOnly = true)
+    public List<AttendanceRangeResponse> getAttendancesByRange(Long requesterId, Long targetMemberId, LocalDate startDate, LocalDate endDate) {
+        Member target = resolveTarget(requesterId, targetMemberId);
+        return attendanceRepository.findByMemberIdAndWorkDateBetween(target.getId(), startDate, endDate)
+                .stream()
+                .map(AttendanceRangeResponse::from)
+                .toList();
+    }
+
+    private Member resolveTarget(Long requesterId, Long targetMemberId) {
+        Member requester = findMember(requesterId);
+        if (requester.getRole() == MemberRole.ADMIN) {
+            return memberRepository.findById(targetMemberId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         }
+        if (requester.getRole() == MemberRole.TEAM_LEAD) {
+            Member target = memberRepository.findById(targetMemberId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+            validateSameTeam(requester, target);
+            return target;
+        }
+        if (!requesterId.equals(targetMemberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return requester;
     }
 
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Attendance findTodayAttendance(Long memberId) {
+        return attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHECKED_IN));
+    }
+
+    private void validateAttendanceIp(String clientIp) {
+        if (!clientIp.startsWith("220.69")) {
+            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+        }
     }
 
     private void validateNotAlreadyCheckedIn(Long memberId) {
@@ -101,8 +135,9 @@ public class AttendanceService {
                 });
     }
 
-    private Attendance findTodayAttendance(Long memberId) {
-        return attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHECKED_IN));
+    private void validateSameTeam(Member requester, Member target) {
+        if (!requester.getTeam().getName().equals(target.getTeam().getName())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceSettlementService.java
@@ -1,0 +1,170 @@
+package com.yanus.attendance.attendance.application;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementItemResponse;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttendanceSettlementService {
+
+    private static final int FEE_PER_MINUTE = 100;
+
+    private final AttendanceRepository attendanceRepository;
+    private final WorkScheduleRepository workScheduleRepository;
+    private final WorkScheduleEventRepository workScheduleEventRepository;
+    private final MemberRepository memberRepository;
+
+    public AttendanceSettlementResponse getMonthlySettlement(
+            Long requesterId, Long targetMemberId, YearMonth yearMonth) {
+
+        Member requester = findMember(requesterId);
+        Member target = resolveTarget(requester, targetMemberId);
+
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth();
+
+        Map<LocalDate, WorkScheduleEvent> eventMap = workScheduleEventRepository
+                .findAllByMemberIdAndDateBetween(target.getId(), start, end)
+                .stream()
+                .collect(Collectors.toMap(WorkScheduleEvent::getDate, e -> e));
+
+        List<WorkSchedule> schedules = workScheduleRepository.findAllByMemberId(target.getId());
+
+        Map<LocalDate, Attendance> attendanceMap = attendanceRepository
+                .findByMemberIdAndWorkDateBetween(target.getId(), start, end)
+                .stream()
+                .collect(Collectors.toMap(Attendance::getWorkDate, a -> a));
+
+        List<AttendanceSettlementItemResponse> items = start.datesUntil(end.plusDays(1))
+                .filter(date -> isScheduledDay(date, schedules, eventMap))
+                .map(date -> buildItem(date, schedules, eventMap, attendanceMap))
+                .toList();
+
+        return aggregate(target, yearMonth, items);
+    }
+
+    private boolean isScheduledDay(LocalDate date,
+                                   List<WorkSchedule> schedules, Map<LocalDate, WorkScheduleEvent> eventMap) {
+        if (eventMap.containsKey(date)) {
+            return true;
+        }
+        return schedules.stream().anyMatch(s -> s.getDayOfWeek() == date.getDayOfWeek());
+    }
+
+    private AttendanceSettlementItemResponse buildItem(
+            LocalDate date,
+            List<WorkSchedule> schedules,
+            Map<LocalDate, WorkScheduleEvent> eventMap,
+            Map<LocalDate, Attendance> attendanceMap) {
+
+        LocalTime scheduledStart;
+        LocalTime scheduledEnd;
+
+        if (eventMap.containsKey(date)) {
+            WorkScheduleEvent event = eventMap.get(date);
+            scheduledStart = event.getStartTime();
+            scheduledEnd = event.getEndTime();
+        } else {
+            WorkSchedule schedule = schedules.stream()
+                    .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
+                    .findFirst()
+                    .orElseThrow();
+            scheduledStart = schedule.getStartTime();
+            scheduledEnd = schedule.getEndTime();
+        }
+
+        Attendance attendance = attendanceMap.get(date);
+        if (attendance == null) {
+            return new AttendanceSettlementItemResponse(
+                    date, scheduledStart, scheduledEnd, null, null, 0, 0, AttendanceSettlementStatus.ABSENT);
+        }
+
+        int lateMinutes = calculateLateMinutes(scheduledStart, attendance);
+        int fee = lateMinutes * FEE_PER_MINUTE;
+        AttendanceSettlementStatus status = lateMinutes > 0
+                ? AttendanceSettlementStatus.LATE
+                : AttendanceSettlementStatus.ON_TIME;
+
+        return new AttendanceSettlementItemResponse(
+                date, scheduledStart, scheduledEnd,
+                attendance.getCheckInTime(), attendance.getCheckOutTime(),
+                lateMinutes, fee, status);
+    }
+
+    private int calculateLateMinutes(LocalTime scheduledStart, Attendance attendance) {
+        LocalTime checkIn = attendance.getCheckInTime().toLocalTime().truncatedTo(ChronoUnit.MINUTES);
+        LocalTime scheduled = scheduledStart.truncatedTo(ChronoUnit.MINUTES);
+        long diff = ChronoUnit.MINUTES.between(scheduled, checkIn);
+        return (int) Math.max(0, diff);
+    }
+
+    private AttendanceSettlementResponse aggregate(
+            Member target, YearMonth yearMonth, List<AttendanceSettlementItemResponse> items) {
+
+        int scheduledDays = items.size();
+        int attendedDays = (int) items.stream()
+                .filter(i -> i.status() != AttendanceSettlementStatus.ABSENT)
+                .count();
+        int lateDays = (int) items.stream()
+                .filter(i -> i.status() == AttendanceSettlementStatus.LATE)
+                .count();
+        int totalLateMinutes = items.stream().mapToInt(AttendanceSettlementItemResponse::lateMinutes).sum();
+        int lateFee = totalLateMinutes * FEE_PER_MINUTE;
+
+        return new AttendanceSettlementResponse(
+                yearMonth.toString(),
+                target.getId(),
+                target.getName(),
+                target.getTeam() != null ? target.getTeam().getName() : null,
+                scheduledDays, attendedDays, lateDays, totalLateMinutes, lateFee, items);
+    }
+
+    private Member resolveTarget(Member requester, Long targetMemberId) {
+        if (requester.getRole() == MemberRole.ADMIN) {
+            return findMember(targetMemberId);
+        }
+        if (requester.getRole() == MemberRole.TEAM_LEAD) {
+            Member target = findMember(targetMemberId);
+            validateSameTeam(requester, target);
+            return target;
+        }
+        if (!requester.getId().equals(targetMemberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return requester;
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateSameTeam(Member requester, Member target) {
+        if (!requester.getTeam().getName().equals(target.getTeam().getName())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
@@ -16,5 +16,7 @@ public interface AttendanceRepository {
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
 
+    List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate start, LocalDate end);
+
     void delete(Attendance attendance);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementCalculator.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementCalculator.java
@@ -1,0 +1,21 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+public class AttendanceSettlementCalculator {
+
+    private static final int FEE_PER_MINUTE = 100;
+
+    public static int calculateLateMinutes(LocalTime scheduledStart, LocalDateTime checkIn) {
+        LocalTime checkInTime = checkIn.toLocalTime().truncatedTo(ChronoUnit.MINUTES);
+        LocalTime scheduled = scheduledStart.truncatedTo(ChronoUnit.MINUTES);
+        int diff = (int) ChronoUnit.MINUTES.between(scheduled, checkInTime);
+        return Math.max(0, diff);
+    }
+
+    public static int calculateFee(int lateMinutes) {
+        return lateMinutes * FEE_PER_MINUTE;
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+public enum AttendanceSettlementStatus {
+    ON_TIME, LATE, ABSENT
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -41,6 +41,11 @@ public class AttendanceJpaRepository implements AttendanceRepository {
     }
 
     @Override
+    public List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return repository.findByMemberIdAndWorkDateBetween(memberId, start, end);
+    }
+
+    @Override
     public void delete(Attendance attendance) {
         repository.delete(attendance);
     }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
@@ -16,4 +16,6 @@ public interface AttendanceSpringDataRepository extends JpaRepository<Attendance
     List<Attendance> findAllByWorkDate(LocalDate workDate);
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
+
+    List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation;
 
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import com.yanus.attendance.attendance.application.AttendanceService;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
@@ -53,6 +54,16 @@ public class AttendanceController {
             @RequestParam(required = false) String teamName
     ) {
         return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
+    }
+
+    @GetMapping("/range")
+    public ResponseEntity<ApiResponse<List<AttendanceRangeResponse>>> getAttendancesByRange(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam Long targetMemberId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(
+                attendanceService.getAttendancesByRange(memberId, targetMemberId, startDate, endDate)));
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceSettlementController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceSettlementController.java
@@ -1,0 +1,35 @@
+package com.yanus.attendance.attendance.presentation;
+
+import com.yanus.attendance.attendance.application.AttendanceSettlementService;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지각 정산", description = "월별 지각 정산 조회")
+@RestController
+@RequestMapping("/api/v1/attendance-settlements")
+@RequiredArgsConstructor
+public class AttendanceSettlementController {
+
+    private final AttendanceSettlementService settlementService;
+
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponse<AttendanceSettlementResponse>> getMonthlySettlement(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam String yearMonth,
+            @RequestParam(required = false) Long targetMemberId) {
+
+        Long target = targetMemberId != null ? targetMemberId : memberId;
+
+        return ResponseEntity.ok(ApiResponse.success(
+                settlementService.getMonthlySettlement(memberId, target, YearMonth.parse(yearMonth))));
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceRangeResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceRangeResponse.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.member.domain.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record AttendanceRangeResponse(
+        Long attendanceId,
+        Long memberId,
+        String memberName,
+        String teamName,
+        LocalDate workDate,
+        LocalDateTime checkInTime,
+        LocalDateTime checkOutTime,
+        AttendanceStatus status
+) {
+    public static AttendanceRangeResponse from(Attendance attendance) {
+        Member member = attendance.getMember();
+        return new AttendanceRangeResponse(
+                attendance.getId(),
+                member.getId(),
+                member.getName(),
+                member.getTeam() != null ? member.getTeam().getName() : null,
+                attendance.getWorkDate(),
+                attendance.getCheckInTime(),
+                attendance.getCheckOutTime(),
+                attendance.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementItemResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementItemResponse.java
@@ -1,0 +1,18 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record AttendanceSettlementItemResponse(
+        LocalDate date,
+        LocalTime scheduledStartTime,
+        LocalTime scheduledEndTime,
+        LocalDateTime checkInTime,
+        LocalDateTime checkOutTime,
+        int lateMinutes,
+        int fee,
+        AttendanceSettlementStatus status
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementResponse.java
@@ -1,0 +1,17 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.util.List;
+
+public record AttendanceSettlementResponse(
+        String yearMonth,
+        Long memberId,
+        String memberName,
+        String teamName,
+        int scheduledDays,
+        int attendedDays,
+        int lateDays,
+        int totalLateMinutes,
+        int lateFee,
+        List<AttendanceSettlementItemResponse> items
+) {
+}

--- a/src/main/java/com/yanus/attendance/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yanus/attendance/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.global.exception;
 
 import com.yanus.attendance.global.response.ApiResponse;
+import java.time.format.DateTimeParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -38,5 +39,16 @@ public class GlobalExceptionHandler {
                         ErrorCode.INTERNAL_ERROR.getCode(),
                         ErrorCode.INTERNAL_ERROR.getMessage(),
                         null));
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDateTimeParseException(DateTimeParseException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ApiResponse<>(
+                        ErrorCode.BAD_REQUEST.getCode(),
+                        "yearMonth는 yyyy-MM 형식이어야 합니다",
+                        null
+                ));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -58,4 +58,14 @@ public class FakeAttendanceRepository implements AttendanceRepository {
     public void delete(Attendance attendance) {
         store.remove(attendance.getId());
     }
+
+    @Override
+    public List<Attendance> findByMemberIdAndWorkDateBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate) {
+        return store.values().stream()
+                .filter(a -> a.getMember().getId().equals(memberId))
+                .filter(a -> !a.getWorkDate().isBefore(startDate))
+                .filter(a -> !a.getWorkDate().isAfter(endDate))
+                .toList();
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -1,13 +1,16 @@
 package com.yanus.attendance.attendance.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
@@ -20,6 +23,7 @@ import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,8 +33,10 @@ public class AttendanceServiceTest {
 
     private AttendanceService attendanceService;
     private AttendanceRepository attendanceRepository;
-    private AttendanceQueryRepository attendanceQueryRepository;
     private MemberRepository memberRepository;
+
+    private final AtomicLong memberEmailSeq = new AtomicLong(1);
+    private final AtomicLong teamIdSeq = new AtomicLong(1);
 
     @BeforeEach
     void setUp() {
@@ -38,14 +44,34 @@ public class AttendanceServiceTest {
         memberRepository = new FakeMemberRepository();
         AttendanceQueryRepository attendanceQueryRepository = new FakeAttendanceQueryRepository(attendanceRepository);
         attendanceService = new AttendanceService(attendanceRepository, memberRepository, attendanceQueryRepository);
+        memberEmailSeq.set(1);
+        teamIdSeq.set(1);
     }
 
     private Member createMember() {
+        return createMember(MemberRole.ADMIN);
+    }
+
+    private Member createMember(MemberRole role) {
         Team team = Team.create("1팀");
         ReflectionTestUtils.setField(team, "id", 1L);
-        Member member = Member.create("정용태", "jyt6640@naver.com", "password123", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+        String email = "user" + memberEmailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("정용태", email, "password123", role, MemberStatus.ACTIVE, team);
         return memberRepository.save(member);
     }
+
+    private Member createMemberWithTeam(MemberRole role, Team team) {
+        String email = "user" + memberEmailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("멤버", email, "password123", role, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    private Team createTeam(String name) {
+        Team team = Team.create(name);
+        ReflectionTestUtils.setField(team, "id", teamIdSeq.getAndIncrement());
+        return team;
+    }
+
 
     @Test
     @DisplayName("출근 체크인 시 WORKING 상태로 저장")
@@ -211,5 +237,66 @@ public class AttendanceServiceTest {
         assertThatThrownBy(() -> attendanceService.resetAttendance(member.getId(), LocalDate.now()))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ATTENDANCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("기간별 출근 내역 본인 조회")
+    void get_attendances_by_range() {
+        // given
+        Member member = createMember(MemberRole.MEMBER);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 0, 0));
+        attendanceRepository.save(attendance);
+
+        // when
+        List<AttendanceRangeResponse> result = attendanceService.getAttendancesByRange(
+                member.getId(), member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).workDate()).isEqualTo(LocalDate.of(2026, 3, 4));
+    }
+
+    @Test
+    @DisplayName("팀장은 같은 팀 멤버 출근 내역 조회 가능")
+    void team_lead_can_get_attendances_by_range() {
+        // given
+        Team team = createTeam("1팀");
+        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, team);
+        Member target = createMemberWithTeam(MemberRole.MEMBER, team);
+
+        // when & then
+        assertThatNoException().isThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        leader.getId(), target.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)));
+    }
+
+    @Test
+    @DisplayName("팀장은 다른 팀 멤버 출근 내역 조회 불가")
+    void team_lead_cannot_get_attendances_by_range() {
+        // given
+        Team myTeam = createTeam("1팀");
+        Team otherTeam = createTeam("2팀");
+        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, myTeam);
+        Member other = createMemberWithTeam(MemberRole.MEMBER, otherTeam);
+
+        // when & then
+        assertThatThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        leader.getId(), other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("멤버가 타인 출근 내역 조회 시 예외")
+    void member_cannot_get_attendances_by_range() {
+        // given
+        Member me = createMember(MemberRole.MEMBER);
+        Member other = createMember(MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        me.getId(), other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -1,0 +1,213 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleEventRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementItemResponse;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AttendanceSettlementServiceTest {
+
+    private AttendanceSettlementService settlementService;
+    private AttendanceRepository attendanceRepository;
+    private WorkScheduleRepository workScheduleRepository;
+    private WorkScheduleEventRepository workScheduleEventRepository;
+    private MemberRepository memberRepository;
+
+    private final AtomicLong emailSeq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        attendanceRepository = new FakeAttendanceRepository();
+        workScheduleRepository = new FakeWorkScheduleRepository();
+        workScheduleEventRepository = new FakeWorkScheduleEventRepository();
+        memberRepository = new FakeMemberRepository();
+        settlementService = new AttendanceSettlementService(
+                attendanceRepository, workScheduleRepository,
+                workScheduleEventRepository, memberRepository);
+        emailSeq.set(1);
+    }
+
+    private Member createMember(MemberRole role) {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        String email = "user" + emailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("정용태", email, "password123", role, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    private AttendanceSettlementItemResponse findItem(AttendanceSettlementResponse response, LocalDate date) {
+        return response.items().stream()
+                .filter(i -> i.date().equals(date))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Test
+    @DisplayName("정시 출근은 ON_TIME이고 지각비 0원")
+    void 정시_출근은_ON_TIME이고_지각비_0원() {
+        // given - 2026-03-04 (수요일)
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 8, 55, 0));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.ON_TIME);
+        assertThat(item.lateMinutes()).isZero();
+        assertThat(item.fee()).isZero();
+    }
+
+    @Test
+    @DisplayName("지각 7분 59초는 7분으로 계산하고 700원")
+    void 지각_7분_59초는_7분으로_계산하고_700원() {
+        // given - 2026-03-04 (수요일)
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 7, 59));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.LATE);
+        assertThat(item.lateMinutes()).isEqualTo(7);
+        assertThat(item.fee()).isEqualTo(700);
+    }
+
+    @Test
+    @DisplayName("WorkScheduleEvent가 있으면 반복 일정보다 우선 적용")
+    void WorkScheduleEvent가_있으면_반복_일정보다_우선_적용() {
+        // given - 반복 일정 09:00, 이벤트로 10:00 오버라이드, 10:05 출근
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        WorkScheduleEvent event = WorkScheduleEvent.create(member,
+                LocalDate.of(2026, 3, 4), LocalTime.of(10, 0), LocalTime.of(19, 0));
+        workScheduleEventRepository.save(event);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 10, 5, 0));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then - 이벤트 기준 10:00 대비 5분 지각
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.scheduledStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(item.lateMinutes()).isEqualTo(5);
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.LATE);
+    }
+
+    @Test
+    @DisplayName("근무 일정 없는 날은 items에 포함되지 않는다")
+    void 근무_일정_없는_날은_items에_포함되지_않는다() {
+        // given - 근무 일정 없음
+        Member member = createMember(MemberRole.MEMBER);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        assertThat(result.items()).isEmpty();
+        assertThat(result.scheduledDays()).isZero();
+    }
+
+    @Test
+    @DisplayName("출근 기록 없는 날은 ABSENT이고 지각비 없음")
+    void 출근_기록_없는_날은_ABSENT이고_지각비_없음() {
+        // given - 일정은 있고 출근 기록 없음
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.ABSENT);
+        assertThat(item.fee()).isZero();
+        assertThat(result.lateFee()).isZero();
+    }
+
+    @Test
+    @DisplayName("월별 집계 정상 계산")
+    void 월별_집계_정상_계산() {
+        // given - 3/4 (수) 10분 지각, 3/11 (수) 정시 출근
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 10, 0)));
+        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 11, 9, 0, 0)));
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        assertThat(result.lateDays()).isEqualTo(1);
+        assertThat(result.totalLateMinutes()).isEqualTo(10);
+        assertThat(result.lateFee()).isEqualTo(1000);
+        assertThat(result.attendedDays()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("MEMBER가 타인 정산 조회 시 예외")
+    void MEMBER가_타인_정산_조회_시_예외() {
+        // given
+        Member me = createMember(MemberRole.MEMBER);
+        Member other = createMember(MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() ->
+                settlementService.getMonthlySettlement(
+                        me.getId(), other.getId(), YearMonth.of(2026, 3)))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
@@ -1,0 +1,63 @@
+package com.yanus.attendance.attendance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementCalculator;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AttendanceSettlementCalculatorTest {
+
+    @Test
+    @DisplayName("정시 출근시 요금 0원")
+    void regular_check_in_is_free() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 9, 0, 0);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isZero();
+    }
+
+    @Test
+    void fifteen_nine_minutes_after_scheduled_time_is_late() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 9, 7, 59);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("지각비는 분당 백원")
+    void late_fee_is_per_minute() {
+        // when
+        int fee = AttendanceSettlementCalculator.calculateFee(27);
+
+        // then
+        assertThat(fee).isEqualTo(2700);
+    }
+
+    @Test
+    @DisplayName("조기 출근은 지각비 0원")
+    void early_check_in_is_free() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 8, 50, 0);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isZero();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #134
closes #135

## 작업 내용
- 기간별 출근 내역 조회 기능 추가
- 기간별 출근 내역 조회 API 및 응답 DTO 추가
- 월별 지각 정산 조회 기능 추가
- 월별 지각 정산 API, 정산 상태 enum, 응답 DTO 추가
- 반복 근무 일정과 WorkScheduleEvent를 반영한 월별 지각 정산 로직 구현
- 출근 범위 조회 및 월별 지각 정산 관련 서비스/도메인 테스트 추가 및 보완

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [X] 리팩터링 완료
- [x] 테스트 전체 통과
