### PR TITLE
[AUTH] #139 - 이메일 인증 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ application-prod.properties
 ### Local Dev ###
 CLAUDE.md
 api.md
+AGENTS.md

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	}
 	implementation 'com.google.guava:guava:32.1.3-jre'
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    mailhog:
+      image: mailhog/mailhog
+      ports:
+        - "1025:1025"
+        - "8025:8025"
+
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    mailhog:
-      image: mailhog/mailhog
-      ports:
-        - "1025:1025"
-        - "8025:8025"
 
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
 
 volumes:
   postgres-data:

--- a/src/main/java/com/yanus/attendance/audit/domain/AuditAction.java
+++ b/src/main/java/com/yanus/attendance/audit/domain/AuditAction.java
@@ -1,5 +1,5 @@
 package com.yanus.attendance.audit.domain;
 
 public enum AuditAction {
-    ROLE_CHANGE, TEAM_CHANGE, DEACTIVATE, ACTIVATE
+    ROLE_CHANGE, TEAM_CHANGE, DEACTIVATE, ACTIVATE, PASSWORD_RESET
 }

--- a/src/main/java/com/yanus/attendance/auth/application/AuthService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
                 request.email(),
                 passwordEncoder.encode(request.password()),
                 MemberRole.MEMBER,
-                MemberStatus.ACTIVE,
+                MemberStatus.PENDING,
                 team
         );
         memberRepository.save(member);
@@ -73,6 +73,10 @@ public class AuthService {
 
         if (member.isInactive()) {
             throw new BusinessException(ErrorCode.MEMBER_INACTIVE);
+        }
+
+        if (member.isPending()) {
+            throw new BusinessException(ErrorCode.MEMBER_PENDING);
         }
 
         member.recordLoginSuccess();

--- a/src/main/java/com/yanus/attendance/auth/application/AuthService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/AuthService.java
@@ -32,6 +32,7 @@ public class AuthService {
     private final TeamRepository teamRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
 
     @Transactional
     public void register(RegisterRequest request) {
@@ -50,7 +51,8 @@ public class AuthService {
                 MemberStatus.PENDING,
                 team
         );
-        memberRepository.save(member);
+        Member saved = memberRepository.save(member);
+        emailVerificationService.sendVerification(saved.getId(), saved.getEmail());
     }
 
     @Transactional

--- a/src/main/java/com/yanus/attendance/auth/application/EmailService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailService.java
@@ -1,0 +1,22 @@
+package com.yanus.attendance.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendVerificationEmail(String email, String verificationToken) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[yANUs] 이메일 인증을 완료해주세요");
+        message.setText("아래 토큰을 입력하여 이메일 인증을 완료하세요.\n\n토큰: " + verificationToken
+                + "\n\n토큰은 30분간 유효합니다.");
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
@@ -42,4 +42,10 @@ public class EmailVerificationService {
         verificationToken.use();
         member.activate();
     }
+
+    public void resend(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        sendVerification(member.getId(), member.getEmail());
+    }
 }

--- a/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
@@ -1,0 +1,45 @@
+package com.yanus.attendance.auth.application;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailVerificationService {
+
+    private final EmailVerificationTokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+    private final EmailService emailService;
+
+    public void sendVerification(Long memberId, String email) {
+        tokenRepository.deleteByMemberId(memberId);
+        String token = UUID.randomUUID().toString();
+        tokenRepository.save(EmailVerificationToken.create(token, memberId, LocalDateTime.now().plusMinutes(30)));
+        emailService.sendVerificationEmail(email, token);
+    }
+
+    public void verify(String token) {
+        EmailVerificationToken verificationToken = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_VERIFICATION_TOKEN));
+
+        if (verificationToken.isExpired() || verificationToken.isUsed()) {
+            throw new BusinessException(ErrorCode.INVALID_VERIFICATION_TOKEN);
+        }
+
+        Member member = memberRepository.findById(verificationToken.getMemberId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        verificationToken.use();
+        member.activate();
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationToken.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationToken.java
@@ -1,0 +1,50 @@
+package com.yanus.attendance.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerificationToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used;
+
+    public static EmailVerificationToken create(String token, Long memberId, LocalDateTime expiresAt) {
+        EmailVerificationToken emailVerificationToken = new EmailVerificationToken();
+        emailVerificationToken.token = token;
+        emailVerificationToken.memberId = memberId;
+        emailVerificationToken.expiresAt = expiresAt;
+        emailVerificationToken.used = false;
+        return emailVerificationToken;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void use() {
+        this.used = true;
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
@@ -1,5 +1,7 @@
 package com.yanus.attendance.auth.domain;
 
+import java.util.Optional;
+
 public interface EmailVerificationTokenRepository {
     EmailVerificationToken save(EmailVerificationToken token);
     Optional<EmailVerificationToken> findByToken(String token);

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
@@ -1,0 +1,7 @@
+package com.yanus.attendance.auth.domain;
+
+public interface EmailVerificationTokenRepository {
+    EmailVerificationToken save(EmailVerificationToken token);
+    Optional<EmailVerificationToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenJpaRepository.java
@@ -1,0 +1,29 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationTokenJpaRepository implements EmailVerificationTokenRepository {
+
+    private final EmailVerificationTokenSpringDataRepository repository;
+
+    @Override
+    public EmailVerificationToken save(EmailVerificationToken token) {
+        return repository.save(token);
+    }
+
+    @Override
+    public Optional<EmailVerificationToken> findByToken(String token) {
+        return repository.findByToken(token);
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        repository.deleteByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenSpringDataRepository.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailVerificationTokenSpringDataRepository extends JpaRepository<EmailVerificationToken, Long> {
+    Optional<EmailVerificationToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepository.java
@@ -28,7 +28,3 @@ public class RefreshTokenJpaRepository implements RefreshTokenRepository {
     }
 }
 
-interface RefreshTokenJpaRepositoryPort extends org.springframework.data.jpa.repository.JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByToken(String token);
-    void deleteByMemberId(Long memberId);
-}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepositoryPort.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepositoryPort extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
@@ -1,12 +1,19 @@
 package com.yanus.attendance.auth.presentation;
 
 import com.yanus.attendance.auth.application.AuthService;
+import com.yanus.attendance.auth.application.EmailService;
+import com.yanus.attendance.auth.application.EmailVerificationService;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
 import com.yanus.attendance.auth.presentation.dto.LoginResponse;
 import com.yanus.attendance.auth.presentation.dto.MeResponse;
 import com.yanus.attendance.auth.presentation.dto.RefreshRequest;
 import com.yanus.attendance.auth.presentation.dto.RegisterRequest;
+import com.yanus.attendance.auth.presentation.dto.ResendVerificationRequest;
+import com.yanus.attendance.auth.presentation.dto.VerifyEmailRequest;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.global.response.ApiResponse;
+import com.yanus.attendance.member.domain.Member;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody RegisterRequest request) {
@@ -44,6 +52,18 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal Long memberId) {
         authService.logout(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/verify-email")
+    public ResponseEntity<ApiResponse<Void>> verifyEmail(@RequestBody VerifyEmailRequest request) {
+        emailVerificationService.verify(request.token());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/verify-email/resend")
+    public ResponseEntity<ApiResponse<Void>> resendVerification(@RequestBody ResendVerificationRequest request) {
+        emailVerificationService.resend(request.email());
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
@@ -1,7 +1,6 @@
 package com.yanus.attendance.auth.presentation;
 
 import com.yanus.attendance.auth.application.AuthService;
-import com.yanus.attendance.auth.application.EmailService;
 import com.yanus.attendance.auth.application.EmailVerificationService;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
 import com.yanus.attendance.auth.presentation.dto.LoginResponse;
@@ -10,10 +9,7 @@ import com.yanus.attendance.auth.presentation.dto.RefreshRequest;
 import com.yanus.attendance.auth.presentation.dto.RegisterRequest;
 import com.yanus.attendance.auth.presentation.dto.ResendVerificationRequest;
 import com.yanus.attendance.auth.presentation.dto.VerifyEmailRequest;
-import com.yanus.attendance.global.exception.BusinessException;
-import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.global.response.ApiResponse;
-import com.yanus.attendance.member.domain.Member;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/yanus/attendance/auth/presentation/dto/ResendVerificationRequest.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/dto/ResendVerificationRequest.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.auth.presentation.dto;
+
+public record ResendVerificationRequest(
+        String email
+) {
+}

--- a/src/main/java/com/yanus/attendance/auth/presentation/dto/VerifyEmailRequest.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/dto/VerifyEmailRequest.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.auth.presentation.dto;
+
+public record VerifyEmailRequest(
+        String token
+) {
+}

--- a/src/main/java/com/yanus/attendance/global/config/SecurityConfig.java
+++ b/src/main/java/com/yanus/attendance/global/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/verify-email").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/verify-email/resend").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", "Refresh Token이 존재하지 않습니다."),
     TOKEN_REUSED(HttpStatus.UNAUTHORIZED, "TOKEN_REUSED", "이미 사용된 토큰입니다. 재로그인이 필요합니다."),
     ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "ACCOUNT_LOCKED", "로그인 시도 횟수를 초과하여 계정이 잠겼습니다. 30분 후 재시도해주세요."),
+    INVALID_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_VERIFICATION_TOKEN", "유효하지 않은 인증 토큰입니다."),
+    EXPIRED_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "EXPIRED_VERIFICATION_TOKEN", "만료된 인증 토큰입니다."),
+
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS", "이미 사용 중인 이메일입니다."),
     MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER_INACTIVE", "비활성화된 계정입니다."),
+    MEMBER_PENDING(HttpStatus.FORBIDDEN, "MEMBER_PENDING", "이메일 인증되지 않은 계정입니다."),
 
     // Attendance
     ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "ALREADY_CHECKED_IN", "이미 출근 처리되었습니다."),

--- a/src/main/java/com/yanus/attendance/member/application/MemberService.java
+++ b/src/main/java/com/yanus/attendance/member/application/MemberService.java
@@ -105,6 +105,7 @@ public class MemberService {
         Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         String temporaryPassword = generateTemporaryPassword();
+        validateAdmin(actorId);
         target.updateProfile(null, temporaryPassword, passwordEncoder);
         auditLogService.log(actorId, actor.getRole(), targetId,
                 AuditAction.PASSWORD_RESET, null, null);

--- a/src/main/java/com/yanus/attendance/member/application/MemberService.java
+++ b/src/main/java/com/yanus/attendance/member/application/MemberService.java
@@ -11,6 +11,7 @@ import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import com.yanus.attendance.team.domain.Team;
 import com.yanus.attendance.team.domain.TeamRepository;
 import java.util.List;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -96,6 +98,19 @@ public class MemberService {
                 AuditAction.TEAM_CHANGE, previousTeam, team.getName());
     }
 
+    @Transactional
+    public TemporaryPasswordResponse resetPassword(Long actorId, Long targetId) {
+        Member actor = memberRepository.findById(actorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Member target = memberRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        String temporaryPassword = generateTemporaryPassword();
+        target.updateProfile(null, temporaryPassword, passwordEncoder);
+        auditLogService.log(actorId, actor.getRole(), targetId,
+                AuditAction.PASSWORD_RESET, null, null);
+        return new TemporaryPasswordResponse(temporaryPassword);
+    }
+
     private Member validateAdmin(Long actorId) {
         Member actor = memberRepository.findById(actorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -115,5 +130,15 @@ public class MemberService {
             return;
         }
         throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+
+    private String generateTemporaryPassword() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(8);
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/yanus/attendance/member/domain/Member.java
+++ b/src/main/java/com/yanus/attendance/member/domain/Member.java
@@ -115,4 +115,8 @@ public class Member {
     public void changeTeam(Team team) {
         this.team = team;
     }
+
+    public boolean isPending() {
+        return this.status == MemberStatus.PENDING;
+    }
 }

--- a/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
 import com.yanus.attendance.member.presentation.dto.TeamChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -76,6 +78,13 @@ public class MemberController {
             @RequestBody TeamChangeRequest request) {
         memberService.changeTeam(actorId, memberId, request.teamId());
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/{memberId}/reset-password")
+    public ResponseEntity<ApiResponse<TemporaryPasswordResponse>> resetPassword(
+            @AuthenticationPrincipal Long actorId,
+            @PathVariable Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(memberService.resetPassword(actorId, memberId)));
     }
 
     @PutMapping("/me")

--- a/src/main/java/com/yanus/attendance/member/presentation/dto/TemporaryPasswordResponse.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/dto/TemporaryPasswordResponse.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.member.presentation.dto;
+
+public record TemporaryPasswordResponse(
+        String temporaryPassword
+) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,13 @@ minio.endpoint=${MINIO_ENDPOINT}
 minio.access-key=${MINIO_ACCESS_KEY}
 minio.secret-key=${MINIO_SECRET_KEY}
 minio.bucket=${MINIO_BUCKET:yanus-files}
+
+# =====================
+# Mail
+# =====================
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/db/migration/V17__create_work_schedule_event.sql
+++ b/src/main/resources/db/migration/V17__create_work_schedule_event.sql
@@ -1,10 +1,10 @@
 CREATE TABLE work_schedule_event (
-                                     work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                                     member_id   BIGINT    NOT NULL,
-                                     date        DATE      NOT NULL,
-                                     start_time  TIME      NOT NULL,
-                                     end_time    TIME      NOT NULL,
-                                     created_at  TIMESTAMP NOT NULL,
-                                     FOREIGN KEY (member_id) REFERENCES member(member_id),
-                                     UNIQUE (member_id, date)
+    work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    member_id   BIGINT    NOT NULL,
+    date        DATE      NOT NULL,
+    start_time  TIME      NOT NULL,
+    end_time    TIME      NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member(member_id),
+    UNIQUE (member_id, date)
 );

--- a/src/main/resources/db/migration/V18__create_email_verification_token.sql
+++ b/src/main/resources/db/migration/V18__create_email_verification_token.sql
@@ -1,0 +1,8 @@
+CREATE TABLE email_verification_token (
+    id          BIGSERIAL PRIMARY KEY,
+    token       VARCHAR(64) NOT NULL UNIQUE,
+    member_id   BIGINT      NOT NULL REFERENCES member(id),
+    expires_at  TIMESTAMP   NOT NULL,
+    used        BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMP   NOT NULL DEFAULT now()
+);

--- a/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
+++ b/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.auth;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class FakeEmailVerificationTokenRepository {
+
+    private final Map<Lomg, EmailVerificationToken> store = new HashMap<>();
+    private long sequence = 1;
+
+    @Override
+    public EmailVerificationToken save(EmailVerificationToken token) {
+        store.put(sequence++, token);
+        return token;
+    }
+
+    @Override
+    public Optional<EmailVerificationToken> findByToken(String token) {
+        return store.values().stream()
+                .filter(t -> t.getToken().equals(token))
+                .findFirst();
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        store.values().removeIf(t -> t.getMemberId().equals(memberId));
+    }
+
+    public List<EmailVerificationToken> findAll() {
+        return new ArrayList<>(store.values());
+    }
+}

--- a/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
+++ b/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
@@ -1,11 +1,16 @@
 package com.yanus.attendance.auth;
 
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-public class FakeEmailVerificationTokenRepository {
+public class FakeEmailVerificationTokenRepository implements EmailVerificationTokenRepository {
 
-    private final Map<Lomg, EmailVerificationToken> store = new HashMap<>();
+    private final Map<Long, EmailVerificationToken> store = new HashMap<>();
     private long sequence = 1;
 
     @Override

--- a/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
@@ -2,7 +2,11 @@ package com.yanus.attendance.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 
+import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
 import com.yanus.attendance.auth.FakeRefreshTokenRepository;
 import com.yanus.attendance.auth.infrastructure.JwtTokenProvider;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
@@ -13,6 +17,7 @@ import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +43,12 @@ class AuthServiceTest {
                 3600000L,
                 604800000L
         );
+
+        EmailService emailService = mock(EmailService.class);
+        doNothing().when(emailService).sendVerificationEmail(anyString(), anyString());
+        EmailVerificationService emailVerificationService = new EmailVerificationService(
+                new FakeEmailVerificationTokenRepository(), memberRepository, emailService);
+
         authService = new AuthService(
                 memberRepository,
                 refreshTokenRepository,
@@ -89,6 +100,7 @@ class AuthServiceTest {
 
         // when
         LoginResponse response = authService.login(request);
+        memberRepository.findByEmail("hong@yanus.com").get().activate();
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -276,5 +288,32 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "wrongpassword")))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_LOCKED);
+    }
+
+    @Test
+    @DisplayName("회원가입 후 PENDING 상태로 저장")
+    void register_saves_member_as_pending_status() {
+        // given
+        Team team = savedTeam();
+
+        // when
+        authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+
+        // then
+        assertThat(memberRepository.findByEmail("hong@yanus.com").get().getStatus())
+                .isEqualTo(MemberStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 멤버 로그인 시 예외 발생")
+    void PENDING_member_login_throw_error() {
+        // given
+        Team team = savedTeam();
+        authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "password123")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_PENDING);
     }
 }

--- a/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
@@ -54,12 +54,17 @@ class AuthServiceTest {
                 refreshTokenRepository,
                 teamRepository,
                 jwtTokenProvider,
-                new BCryptPasswordEncoder()
+                new BCryptPasswordEncoder(),
+                emailVerificationService
         );
     }
 
     private Team savedTeam() {
         return teamRepository.save(Team.create("1팀"));
+    }
+
+    private void activate(String email) {
+        memberRepository.findByEmail(email).get().activate();
     }
 
     @Test
@@ -96,11 +101,11 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginRequest request = new LoginRequest("hong@yanus.com", "password123");
 
         // when
         LoginResponse response = authService.login(request);
-        memberRepository.findByEmail("hong@yanus.com").get().activate();
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -140,6 +145,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         RefreshRequest request = new RefreshRequest(loginResponse.refreshToken());
 
@@ -170,6 +176,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
 
         // when
@@ -186,6 +193,7 @@ class AuthServiceTest {
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
         Member member = memberRepository.findByEmail("hong@yanus.com").get();
+        member.activate();
         member.deactivate();
         LoginRequest request = new LoginRequest("hong@yanus.com", "password123");
 
@@ -201,6 +209,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("김인직", "asdasd@naver.com", "asdasd12", team.getId()));
+        activate("asdasd@naver.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("asdasd@naver.com", "asdasd12"));
         String oldRefreshToken = loginResponse.refreshToken();
 
@@ -218,9 +227,10 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         String oldRefreshToken = loginResponse.refreshToken();
-        authService.refresh(new RefreshRequest(oldRefreshToken)); // 1회 사용
+        authService.refresh(new RefreshRequest(oldRefreshToken));
 
         // when & then
         assertThatThrownBy(() -> authService.refresh(new RefreshRequest(oldRefreshToken)))
@@ -234,6 +244,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         String oldRefreshToken = loginResponse.refreshToken();
         LoginResponse rotated = authService.refresh(new RefreshRequest(oldRefreshToken));
@@ -272,6 +283,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         for (int i = 0; i < 4; i++) {
             assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "wrongpassword")))
                     .isInstanceOf(BusinessException.class);

--- a/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
@@ -1,0 +1,101 @@
+package com.yanus.attendance.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailVerificationServiceTest {
+
+    private EmailVerificationService emailVerificationService;
+    private FakeMemberRepository memberRepository;
+    private FakeEmailVerificationTokenRepository tokenRepository;
+
+    @BeforeEach
+    public void setUp() {
+        memberRepository = new FakeMemberRepository();
+        tokenRepository = new FakeEmailVerificationTokenRepository();
+        EmailService emailService = mock(EmailService.class);
+        doNothing().when(emailService).sendVerification(anyString(), anyString());
+        emailVerificationService = new EmailVerificationService(tokenRepository, memberRepository, emailService);
+    }
+
+    private Member createMember() {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("홍길동", "hong@yanus.com", "password123",
+                MemberRole.MEMBER, MemberStatus.PENDING, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("인증 토큰으로 인증 시 ACTIVE로 변경")
+    void token_verification_active() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String token = tokenRepository.findAll().get(0).getToken();
+
+        // when
+        emailVerificationService.verify(token);
+
+        // then
+        assertThat(memberRepository.findById(member.getId().get().getStatus()))
+                .isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토큰으로 인증 시 예외 발생")
+    void invalid_token_try_verify_is_error() {
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verify("invalid-tokenn"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCodee", ErrorCode.INVALID_VERIFICATION_TOKEN);
+    }
+
+    @Test
+    @DisplayName("재발송 시 기존 토큰 삭제 후 새 토큰 발급")
+    void if_retry_old_token_remove_new_token_serve() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String firstToken = tokenRepository.findAll().get(0).getToken();
+
+        // when
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String secondToken = tokenRepository.findAll().get(0).getToken();
+
+        // then
+        assertThat(firstToken).isNotEqualTo(secondToken);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 토큰으로 인증 시 예외 발생")
+    void used_token_try_verify_is_error() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String token = tokenRepository.findAll().get(0).getToken();
+        emailVerificationService.verify(token);
+
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verify(token))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_VERIFICATION_TOKEN);
+    }
+}

--- a/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
-import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
@@ -28,10 +27,10 @@ public class EmailVerificationServiceTest {
 
     @BeforeEach
     public void setUp() {
-        memberRepository = new FakeMemberRepository();
         tokenRepository = new FakeEmailVerificationTokenRepository();
+        memberRepository = new FakeMemberRepository();
         EmailService emailService = mock(EmailService.class);
-        doNothing().when(emailService).sendVerification(anyString(), anyString());
+        doNothing().when(emailService).sendVerificationEmail(anyString(), anyString());
         emailVerificationService = new EmailVerificationService(tokenRepository, memberRepository, emailService);
     }
 
@@ -55,7 +54,7 @@ public class EmailVerificationServiceTest {
         emailVerificationService.verify(token);
 
         // then
-        assertThat(memberRepository.findById(member.getId().get().getStatus()))
+        assertThat(memberRepository.findById(member.getId()).get().getStatus())
                 .isEqualTo(MemberStatus.ACTIVE);
     }
 
@@ -65,7 +64,7 @@ public class EmailVerificationServiceTest {
         // when & then
         assertThatThrownBy(() -> emailVerificationService.verify("invalid-tokenn"))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCodee", ErrorCode.INVALID_VERIFICATION_TOKEN);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_VERIFICATION_TOKEN);
     }
 
     @Test

--- a/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
@@ -16,6 +16,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import org.junit.jupiter.api.BeforeEach;
@@ -396,13 +397,13 @@ public class MemberServiceTest {
         Member target = createMember("target@yanus.com", MemberRole.MEMBER);
 
         // when
-        TeamPoraryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
+        TemporaryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
 
         // then
         assertThat(response.temporaryPassword()).hasSize(8);
     }
 
-    Test
+    @Test
     @DisplayName("임시 비밀번호 발급 후 변경된 비밀번호로 인코딩 저장")
     void 임시_비밀번호_발급_후_인코딩_저장() {
         // given

--- a/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
@@ -387,4 +387,75 @@ public class MemberServiceTest {
         assertThat(auditLogRepository.findAll()).hasSize(1);
         assertThat(auditLogRepository.findAll().get(0).getAction()).isEqualTo(AuditAction.TEAM_CHANGE);
     }
+
+    @Test
+    @DisplayName("관리자가 임시 비밀번호 발급")
+    void 관리자가_임시_비밀번호_발급() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when
+        TeamPoraryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(response.temporaryPassword()).hasSize(8);
+    }
+
+    Test
+    @DisplayName("임시 비밀번호 발급 후 변경된 비밀번호로 인코딩 저장")
+    void 임시_비밀번호_발급_후_인코딩_저장() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+        String originalPassword = target.getPassword();
+
+        // when
+        memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(memberRepository.findById(target.getId()).get().getPassword())
+                .isNotEqualTo(originalPassword);
+    }
+
+    @Test
+    @DisplayName("ADMIN이 아니면 임시 비밀번호 발급 시 FORBIDDEN")
+    void ADMIN이_아니면_임시_비밀번호_발급_시_FORBIDDEN() {
+        // given
+        Member actor = createMember("actor@yanus.com", MemberRole.MEMBER);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.resetPassword(actor.getId(), target.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버 임시 비밀번호 발급 시 MEMBER_NOT_FOUND")
+    void 존재하지_않는_멤버_임시_비밀번호_발급_시_MEMBER_NOT_FOUND() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.resetPassword(admin.getId(), 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("임시 비밀번호 발급 시 감사 로그 저장")
+    void 임시_비밀번호_발급_시_감사_로그_저장() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when
+        memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(auditLogRepository.findAll()).hasSize(1);
+        assertThat(auditLogRepository.findAll().get(0).getAction())
+                .isEqualTo(AuditAction.PASSWORD_RESET);
+    }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,3 +19,13 @@ minio.access-key=test
 minio.secret-key=testpassword
 minio.bucket=test-bucket
 
+# =====================
+# Mail (테스트용 더미)
+# =====================
+spring.mail.host=localhost
+spring.mail.port=25
+spring.mail.username=test
+spring.mail.password=test
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+


### PR DESCRIPTION
## 관련 이슈
closes #139

## 작업 내용
- 회원가입 시 이메일 인증 메일 발송 및 MemberStatus PENDING 처리
- 이메일 인증 완료 시 ACTIVE로 상태 변경 (`POST /api/v1/auth/verify-email`)
- 인증 메일 재발송 기능 추가 (`POST /api/v1/auth/verify-email/resend`)
- PENDING 상태 멤버 로그인 차단
- EmailVerificationToken 도메인 및 V18 마이그레이션 추가
- spring-boot-starter-mail 의존성 추가 및 Gmail SMTP 설정

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
