### PR TITLE
[v3.5] #139 - 이메일 인증 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ application-prod.properties
 ### Local Dev ###
 CLAUDE.md
 api.md
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | **Team** | 팀 초기 데이터 구성 | ✅ 완료 |
 | **Auth** | 이메일 로그인, JWT 발급/재발급/로그아웃, 내 정보 조회 | ✅ 완료 |
 | **Member** | 회원 목록/상세 조회, 역할 변경, 활성화/비활성화, 프로필 수정 | ✅ 완료 |
-| **Attendance** | 출근/퇴근 체크인, 내 기록 조회, 관리자 조회(팀/날짜 필터), 자정 자동 퇴근, 개인 근무 일정 설정 | ✅ 완료 |
+| **Attendance** | 출근/퇴근 체크인 (IP 검증), 내 기록 조회, 관리자 조회(팀/날짜 필터), 자정 자동 퇴근, 출근 기록 초기화, 개인 근무 일정 설정 (weekPattern), 날짜별 근무 일정 오버라이드 (WorkScheduleEvent), 기간별 출근 내역 조회, 월별 지각 정산 조회 | ✅ 완료 |
 | **Leave** | 휴가 신청, 본인/팀 목록 조회, 승인/반려 | ✅ 완료 |
 | **Task** | 개인/팀 Task 생성, 완료 토글, 수정/삭제, 목록 조회(날짜 범위 필터) | ✅ 완료 |
 | **Calendar** | 이벤트 생성/수정/삭제, 날짜 범위 조회, 생성자 기준 조회 | ✅ 완료 |
@@ -70,8 +70,8 @@ com.yanus.attendance
 ├── auth/
 ├── member/
 ├── attendance/
-│   ├── domain/           # Attendance, WorkSchedule, Repository 인터페이스
-│   ├── application/      # AttendanceService, WorkScheduleService, AttendanceScheduler
+│   ├── domain/           # Attendance, WorkSchedule, WorkScheduleEvent, AttendanceSettlementStatus, Repository 인터페이스
+│   ├── application/      # AttendanceService, WorkScheduleService, WorkScheduleEventService, AttendanceSettlementService, AttendanceScheduler
 │   ├── infrastructure/   # JPA 구현체, QueryDSL
 │   └── presentation/     # Controller, dto/
 ├── leave/

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	}
 	implementation 'com.google.guava:guava:32.1.3-jre'
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    mailhog:
+      image: mailhog/mailhog
+      ports:
+        - "1025:1025"
+        - "8025:8025"
+
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,12 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    mailhog:
-      image: mailhog/mailhog
-      ports:
-        - "1025:1025"
-        - "8025:8025"
 
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
 
 volumes:
   postgres-data:

--- a/docs/troubleshooting/attendance.md
+++ b/docs/troubleshooting/attendance.md
@@ -43,7 +43,74 @@ member_id BIGINT NOT NULL REFERENCES member(member_id)
 
 ---
 
-### 3. 동일 경로에 두 메서드가 매핑되어 contextLoads() 실패
+### 3. V15 audit_log 마이그레이션 AUTO_INCREMENT 문법 오류 → 502
+
+**증상**
+```
+FlywayMigrateException: Script V15__create_audit_log.sql failed
+ERROR: syntax error at or near "AUTO_INCREMENT"
+```
+서버가 기동되지 않아 모든 API 502 응답.
+
+**원인**
+`AUTO_INCREMENT`는 MySQL 문법. PostgreSQL에서는 사용 불가.
+
+**해결**
+```sql
+-- Before
+audit_log_id BIGINT AUTO_INCREMENT PRIMARY KEY
+
+-- After
+audit_log_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+```
+
+---
+
+### 4. 로컬 신규 DB 세팅 시 회원가입 불가 — 닭이냐 달걀이냐
+
+**증상**
+회원가입 요청 시 `NOT_FOUND` 응답. API가 아무것도 안 되는 것처럼 보임.
+
+**원인**
+V12 마이그레이션에서 기본 팀 데이터를 전부 삭제함.
+팀이 없으면 회원가입 불가 → 유저가 없으면 팀 생성 API(ADMIN 전용) 호출 불가.
+
+**해결**
+Docker로 직접 초기 데이터 INSERT.
+```bash
+docker exec -i yanus-postgres psql -U yanus -d yanus -c "
+INSERT INTO team (name, created_at) VALUES ('개발팀', NOW()), ('신입', NOW()) ON CONFLICT (name) DO NOTHING;
+INSERT INTO member (name, email, password, role, team_id, status, created_at)
+SELECT '관리자', 'admin@test.com',
+'\$2a\$10\$Wb1BjoFhUBjxDHyGv94MTOtVmKJ2tjQPUy5i19qe/Tbi3QJ8s4eBS',
+'ADMIN', team_id, 'ACTIVE', NOW()
+FROM team WHERE name = '개발팀' ON CONFLICT (email) DO NOTHING;
+"
+```
+또는 `data.sql` + `application-local.properties`에 `spring.sql.init.mode=always` / `spring.jpa.defer-datasource-initialization=true` 설정.
+
+---
+
+### 5. 로컬에서 체크인 시 INVALID_ATTENDANCE_IP (403)
+
+**증상**
+로컬에서 체크인 API 호출 시 `INVALID_ATTENDANCE_IP` 403 응답.
+
+**원인**
+체크인은 `220.69` 대역 IP만 허용. 로컬 요청은 `127.0.0.1`로 들어와 차단됨.
+
+**해결**
+`X-Forwarded-For` 헤더로 허용 IP를 흉내내어 테스트.
+```bash
+curl -X POST http://localhost:8080/api/v1/attendances/check-in \
+  -H "Authorization: Bearer {토큰}" \
+  -H "X-Forwarded-For: 220.69.1.1"
+```
+Swagger UI는 임의 헤더 추가 불가 → curl 사용 필요.
+
+---
+
+### 6. 동일 경로에 두 메서드가 매핑되어 contextLoads() 실패
 
 **증상**
 ```

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -86,15 +86,16 @@ public class AttendanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<AttendanceRangeResponse> getAttendancesByRange(Member requester, Long targetMemberId, LocalDate startDate, LocalDate endDate) {
-        Member target = resolveTarget(requester, targetMemberId);
+    public List<AttendanceRangeResponse> getAttendancesByRange(Long requesterId, Long targetMemberId, LocalDate startDate, LocalDate endDate) {
+        Member target = resolveTarget(requesterId, targetMemberId);
         return attendanceRepository.findByMemberIdAndWorkDateBetween(target.getId(), startDate, endDate)
                 .stream()
                 .map(AttendanceRangeResponse::from)
                 .toList();
     }
 
-    private Member resolveTarget(Member requester, Long targetMemberId) {
+    private Member resolveTarget(Long requesterId, Long targetMemberId) {
+        Member requester = findMember(requesterId);
         if (requester.getRole() == MemberRole.ADMIN) {
             return memberRepository.findById(targetMemberId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -105,7 +106,7 @@ public class AttendanceService {
             validateSameTeam(requester, target);
             return target;
         }
-        if (!requester.getId().equals(targetMemberId)) {
+        if (!requesterId.equals(targetMemberId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
         return requester;

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -1,9 +1,9 @@
 package com.yanus.attendance.attendance.application;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -4,11 +4,13 @@ import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -83,15 +85,46 @@ public class AttendanceService {
         attendanceRepository.delete(attendance);
     }
 
-    private void validateAttendanceIp(String clientIp) {
-        if (!clientIp.startsWith("220.69")) {
-            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+    @Transactional(readOnly = true)
+    public List<AttendanceRangeResponse> getAttendancesByRange(Member requester, Long targetMemberId, LocalDate startDate, LocalDate endDate) {
+        Member target = resolveTarget(requester, targetMemberId);
+        return attendanceRepository.findByMemberIdAndWorkDateBetween(target.getId(), startDate, endDate)
+                .stream()
+                .map(AttendanceRangeResponse::from)
+                .toList();
+    }
+
+    private Member resolveTarget(Member requester, Long targetMemberId) {
+        if (requester.getRole() == MemberRole.ADMIN) {
+            return memberRepository.findById(targetMemberId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         }
+        if (requester.getRole() == MemberRole.TEAM_LEAD) {
+            Member target = memberRepository.findById(targetMemberId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+            validateSameTeam(requester, target);
+            return target;
+        }
+        if (!requester.getId().equals(targetMemberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return requester;
     }
 
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Attendance findTodayAttendance(Long memberId) {
+        return attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHECKED_IN));
+    }
+
+    private void validateAttendanceIp(String clientIp) {
+        if (!clientIp.startsWith("220.69")) {
+            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+        }
     }
 
     private void validateNotAlreadyCheckedIn(Long memberId) {
@@ -101,8 +134,9 @@ public class AttendanceService {
                 });
     }
 
-    private Attendance findTodayAttendance(Long memberId) {
-        return attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHECKED_IN));
+    private void validateSameTeam(Member requester, Member target) {
+        if (!requester.getTeam().getName().equals(target.getTeam().getName())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -68,6 +68,21 @@ public class AttendanceService {
         workingAttendances.forEach(attendance -> attendance.checkOut(checkOutTime));
     }
 
+    public AttendanceResponse checkIn(Long memberId, String clientIp) {
+        validateAttendanceIp(clientIp);
+        Member member = findMember(memberId);
+        validateNotAlreadyCheckedIn(memberId);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now());
+        attendanceRepository.save(attendance);
+        return AttendanceResponse.from(attendance);
+    }
+
+    private void validateAttendanceIp(String clientIp) {
+        if (!clientIp.startsWith("220.69")) {
+            throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);
+        }
+    }
+
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceService.java
@@ -77,6 +77,12 @@ public class AttendanceService {
         return AttendanceResponse.from(attendance);
     }
 
+    public void resetAttendance(Long memberId, LocalDate today) {
+        Attendance attendance = attendanceRepository.findByMemberIdAndWorkDate(memberId, today)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ATTENDANCE_NOT_FOUND));
+        attendanceRepository.delete(attendance);
+    }
+
     private void validateAttendanceIp(String clientIp) {
         if (!clientIp.startsWith("220.69")) {
             throw new BusinessException(ErrorCode.INVALID_ATTENDANCE_IP);

--- a/src/main/java/com/yanus/attendance/attendance/application/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/AttendanceSettlementService.java
@@ -1,0 +1,170 @@
+package com.yanus.attendance.attendance.application;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementItemResponse;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttendanceSettlementService {
+
+    private static final int FEE_PER_MINUTE = 100;
+
+    private final AttendanceRepository attendanceRepository;
+    private final WorkScheduleRepository workScheduleRepository;
+    private final WorkScheduleEventRepository workScheduleEventRepository;
+    private final MemberRepository memberRepository;
+
+    public AttendanceSettlementResponse getMonthlySettlement(
+            Long requesterId, Long targetMemberId, YearMonth yearMonth) {
+
+        Member requester = findMember(requesterId);
+        Member target = resolveTarget(requester, targetMemberId);
+
+        LocalDate start = yearMonth.atDay(1);
+        LocalDate end = yearMonth.atEndOfMonth();
+
+        Map<LocalDate, WorkScheduleEvent> eventMap = workScheduleEventRepository
+                .findAllByMemberIdAndDateBetween(target.getId(), start, end)
+                .stream()
+                .collect(Collectors.toMap(WorkScheduleEvent::getDate, e -> e));
+
+        List<WorkSchedule> schedules = workScheduleRepository.findAllByMemberId(target.getId());
+
+        Map<LocalDate, Attendance> attendanceMap = attendanceRepository
+                .findByMemberIdAndWorkDateBetween(target.getId(), start, end)
+                .stream()
+                .collect(Collectors.toMap(Attendance::getWorkDate, a -> a));
+
+        List<AttendanceSettlementItemResponse> items = start.datesUntil(end.plusDays(1))
+                .filter(date -> isScheduledDay(date, schedules, eventMap))
+                .map(date -> buildItem(date, schedules, eventMap, attendanceMap))
+                .toList();
+
+        return aggregate(target, yearMonth, items);
+    }
+
+    private boolean isScheduledDay(LocalDate date,
+                                   List<WorkSchedule> schedules, Map<LocalDate, WorkScheduleEvent> eventMap) {
+        if (eventMap.containsKey(date)) {
+            return true;
+        }
+        return schedules.stream().anyMatch(s -> s.getDayOfWeek() == date.getDayOfWeek());
+    }
+
+    private AttendanceSettlementItemResponse buildItem(
+            LocalDate date,
+            List<WorkSchedule> schedules,
+            Map<LocalDate, WorkScheduleEvent> eventMap,
+            Map<LocalDate, Attendance> attendanceMap) {
+
+        LocalTime scheduledStart;
+        LocalTime scheduledEnd;
+
+        if (eventMap.containsKey(date)) {
+            WorkScheduleEvent event = eventMap.get(date);
+            scheduledStart = event.getStartTime();
+            scheduledEnd = event.getEndTime();
+        } else {
+            WorkSchedule schedule = schedules.stream()
+                    .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
+                    .findFirst()
+                    .orElseThrow();
+            scheduledStart = schedule.getStartTime();
+            scheduledEnd = schedule.getEndTime();
+        }
+
+        Attendance attendance = attendanceMap.get(date);
+        if (attendance == null) {
+            return new AttendanceSettlementItemResponse(
+                    date, scheduledStart, scheduledEnd, null, null, 0, 0, AttendanceSettlementStatus.ABSENT);
+        }
+
+        int lateMinutes = calculateLateMinutes(scheduledStart, attendance);
+        int fee = lateMinutes * FEE_PER_MINUTE;
+        AttendanceSettlementStatus status = lateMinutes > 0
+                ? AttendanceSettlementStatus.LATE
+                : AttendanceSettlementStatus.ON_TIME;
+
+        return new AttendanceSettlementItemResponse(
+                date, scheduledStart, scheduledEnd,
+                attendance.getCheckInTime(), attendance.getCheckOutTime(),
+                lateMinutes, fee, status);
+    }
+
+    private int calculateLateMinutes(LocalTime scheduledStart, Attendance attendance) {
+        LocalTime checkIn = attendance.getCheckInTime().toLocalTime().truncatedTo(ChronoUnit.MINUTES);
+        LocalTime scheduled = scheduledStart.truncatedTo(ChronoUnit.MINUTES);
+        long diff = ChronoUnit.MINUTES.between(scheduled, checkIn);
+        return (int) Math.max(0, diff);
+    }
+
+    private AttendanceSettlementResponse aggregate(
+            Member target, YearMonth yearMonth, List<AttendanceSettlementItemResponse> items) {
+
+        int scheduledDays = items.size();
+        int attendedDays = (int) items.stream()
+                .filter(i -> i.status() != AttendanceSettlementStatus.ABSENT)
+                .count();
+        int lateDays = (int) items.stream()
+                .filter(i -> i.status() == AttendanceSettlementStatus.LATE)
+                .count();
+        int totalLateMinutes = items.stream().mapToInt(AttendanceSettlementItemResponse::lateMinutes).sum();
+        int lateFee = totalLateMinutes * FEE_PER_MINUTE;
+
+        return new AttendanceSettlementResponse(
+                yearMonth.toString(),
+                target.getId(),
+                target.getName(),
+                target.getTeam() != null ? target.getTeam().getName() : null,
+                scheduledDays, attendedDays, lateDays, totalLateMinutes, lateFee, items);
+    }
+
+    private Member resolveTarget(Member requester, Long targetMemberId) {
+        if (requester.getRole() == MemberRole.ADMIN) {
+            return findMember(targetMemberId);
+        }
+        if (requester.getRole() == MemberRole.TEAM_LEAD) {
+            Member target = findMember(targetMemberId);
+            validateSameTeam(requester, target);
+            return target;
+        }
+        if (!requester.getId().equals(targetMemberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return requester;
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateSameTeam(Member requester, Member target) {
+        if (!requester.getTeam().getName().equals(target.getTeam().getName())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleEventService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleEventService.java
@@ -1,0 +1,69 @@
+package com.yanus.attendance.attendance.application;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WorkScheduleEventService {
+
+    private final WorkScheduleEventRepository workScheduleEventRepository;
+    private final MemberRepository memberRepository;
+
+    public WorkScheduleEventResponse createEvent(Long memberId, WorkScheduleEventRequest request) {
+        Member member = findMember(memberId);
+        validateNoDuplicate(memberId, request.date());
+        WorkScheduleEvent event = WorkScheduleEvent.create(member, request.date(), request.startTime(), request.endTime());
+        workScheduleEventRepository.save(event);
+        return WorkScheduleEventResponse.from(event);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorkScheduleEventResponse> getEvents(Long memberId, LocalDate startDate, LocalDate endDate) {
+        return workScheduleEventRepository.findAllByMemberIdAndDateBetween(memberId, startDate, endDate)
+                .stream().map(WorkScheduleEventResponse::from).toList();
+    }
+
+    public WorkScheduleEventResponse updateEvent(Long memberId, Long eventId, WorkScheduleEventRequest request) {
+        WorkScheduleEvent event = findEventAndValidateOwner(memberId, eventId);
+        event.update(request.startTime(), request.endTime());
+        return WorkScheduleEventResponse.from(event);
+    }
+
+    public void deleteEvent(Long memberId, Long eventId) {
+        WorkScheduleEvent event = findEventAndValidateOwner(memberId, eventId);
+        workScheduleEventRepository.delete(event);
+    }
+
+    private void validateNoDuplicate(Long memberId, LocalDate date) {
+        workScheduleEventRepository.findByMemberIdAndDate(memberId, date)
+                .ifPresent(e -> { throw new BusinessException(ErrorCode.WORK_SCHEDULE_EVENT_DUPLICATE); });
+    }
+
+    private WorkScheduleEvent findEventAndValidateOwner(Long memberId, Long eventId) {
+        WorkScheduleEvent event = workScheduleEventRepository.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
+        if (!event.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return event;
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.application;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
@@ -37,7 +37,7 @@ public class WorkScheduleService {
             return WorkScheduleResponse.from(existing.get());
         }
 
-        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime());
+        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime(), request.weekPattern());
         workScheduleRepository.save(schedule);
 
         return WorkScheduleResponse.from(schedule);
@@ -63,6 +63,12 @@ public class WorkScheduleService {
         return groupByMember(workScheduleRepository.findAll());
     }
 
+    public void deleteWorkSchedule(Long memberId, DayOfWeek dayOfWeek) {
+        workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, dayOfWeek)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
+        workScheduleRepository.deleteByMemberIdAndDayOfWeek(memberId, dayOfWeek);
+    }
+
     private List<MemberWorkScheduleResponse> groupByMember(List<WorkSchedule> schedules) {
         return schedules.stream()
                 .collect(Collectors.groupingBy(WorkSchedule::getMember))
@@ -74,12 +80,6 @@ public class WorkScheduleService {
                         entry.getValue().stream().map(WorkScheduleResponse::from).toList()
                 ))
                 .toList();
-    }
-
-    public void deleteWorkSchedule(Long memberId, DayOfWeek dayOfWeek) {
-        workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, dayOfWeek)
-                .orElseThrow(() -> new BusinessException(ErrorCode.WORK_SCHEDULE_NOT_FOUND));
-        workScheduleRepository.deleteByMemberIdAndDayOfWeek(memberId, dayOfWeek);
     }
 
     private void validateAdmin(Long actorId) {

--- a/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/WorkScheduleService.java
@@ -93,8 +93,7 @@ public class WorkScheduleService {
         if (actor.getRole() == MemberRole.ADMIN) {
             return;
         }
-        if (actor.getRole() == MemberRole.TEAM_LEAD
-                && actor.getTeam().getId().equals(teamId)) {
+        if (actor.getTeam().getId().equals(teamId)) {
             return;
         }
         throw new BusinessException(ErrorCode.FORBIDDEN);

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceRepository.java
@@ -15,4 +15,6 @@ public interface AttendanceRepository {
     List<Attendance> findAllByWorkDate(LocalDate workDate);
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
+
+    void delete(Attendance attendance);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/AttendanceStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/AttendanceStatus.java
@@ -1,5 +1,0 @@
-package com.yanus.attendance.attendance.domain;
-
-public enum AttendanceStatus {
-    WORKING, LEFT
-}

--- a/src/main/java/com/yanus/attendance/attendance/domain/WeekPattern.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/WeekPattern.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain;
+
+public enum WeekPattern {
+    EVERY, FIRST, SECOND, THIRD, FOURTH, LAST
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/WorkSchedule.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/WorkSchedule.java
@@ -19,6 +19,7 @@ import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.checkerframework.checker.units.qual.C;
 
 @Entity
 @Table(name = "work_schedule")
@@ -42,13 +43,19 @@ public class WorkSchedule {
 
     private LocalTime endTime;
 
-    public static WorkSchedule create(Member member, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "week_pattern", nullable = false)
+    private WeekPattern weekPattern;
+
+    public static WorkSchedule create(Member member, DayOfWeek dayOfWeek,
+                                      LocalTime startTime, LocalTime endTime, WeekPattern weekPattern) {
         validateTime(startTime, endTime);
         WorkSchedule schedule = new WorkSchedule();
         schedule.member = member;
         schedule.dayOfWeek = dayOfWeek;
         schedule.startTime = startTime;
         schedule.endTime = endTime;
+        schedule.weekPattern = weekPattern != null ? weekPattern : WeekPattern.EVERY;
         return schedule;
     }
 

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/Attendance.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/Attendance.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceQueryRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceQueryRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
@@ -16,5 +16,7 @@ public interface AttendanceRepository {
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
 
+    List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate start, LocalDate end);
+
     void delete(Attendance attendance);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.attendance;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementCalculator.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementCalculator.java
@@ -1,0 +1,21 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+public class AttendanceSettlementCalculator {
+
+    private static final int FEE_PER_MINUTE = 100;
+
+    public static int calculateLateMinutes(LocalTime scheduledStart, LocalDateTime checkIn) {
+        LocalTime checkInTime = checkIn.toLocalTime().truncatedTo(ChronoUnit.MINUTES);
+        LocalTime scheduled = scheduledStart.truncatedTo(ChronoUnit.MINUTES);
+        int diff = (int) ChronoUnit.MINUTES.between(scheduled, checkInTime);
+        return Math.max(0, diff);
+    }
+
+    public static int calculateFee(int lateMinutes) {
+        return lateMinutes * FEE_PER_MINUTE;
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+public enum AttendanceSettlementStatus {
+    ON_TIME, LATE, ABSENT
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceStatus.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.attendance.domain.attendance;
+
+public enum AttendanceStatus {
+    WORKING, LEFT
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WeekPattern.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WeekPattern.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.workschedule;
 
 public enum WeekPattern {
     EVERY, FIRST, SECOND, THIRD, FOURTH, LAST

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.workschedule;
 
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
@@ -19,7 +19,6 @@ import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.checkerframework.checker.units.qual.C;
 
 @Entity
 @Table(name = "work_schedule")

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
@@ -1,0 +1,64 @@
+package com.yanus.attendance.attendance.domain.workschedule;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "work_schedule_event")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkScheduleEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "work_schedule_event_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private LocalDate date;
+
+    private LocalTime startTime;
+
+    private LocalTime endTime;
+
+    public static WorkScheduleEvent create(Member member, LocalDate date, LocalTime startTime, LocalTime endTime) {
+        validateTime(startTime, endTime);
+        WorkScheduleEvent event = new WorkScheduleEvent();
+        event.member = member;
+        event.date = date;
+        event.startTime = startTime;
+        event.endTime = endTime;
+        return event;
+    }
+
+    public void update(LocalTime startTime, LocalTime endTime) {
+        validateTime(startTime, endTime);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    private static void validateTime(LocalTime startTime, LocalTime endTime) {
+        if (!endTime.isAfter(startTime)) {
+            throw new BusinessException(ErrorCode.INVALID_WORK_SCHEDULE_TIME);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
@@ -1,0 +1,18 @@
+package com.yanus.attendance.attendance.domain.workschedule;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface WorkScheduleEventRepository {
+
+    WorkScheduleEvent save(WorkScheduleEvent event);
+
+    Optional<WorkScheduleEvent> findById(Long id);
+
+    Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date);
+
+    List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    void delete(WorkScheduleEvent event);
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleRepository.java
@@ -1,4 +1,4 @@
-package com.yanus.attendance.attendance.domain;
+package com.yanus.attendance.attendance.domain.workschedule;
 
 import java.time.DayOfWeek;
 import java.util.List;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -39,4 +39,9 @@ public class AttendanceJpaRepository implements AttendanceRepository {
     public List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status) {
         return repository.findAllByWorkDateAndStatus(workDate, status);
     }
+
+    @Override
+    public void delete(Attendance attendance) {
+        repository.delete(attendance);
+    }
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceJpaRepository.java
@@ -41,6 +41,11 @@ public class AttendanceJpaRepository implements AttendanceRepository {
     }
 
     @Override
+    public List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return repository.findByMemberIdAndWorkDateBetween(memberId, start, end);
+    }
+
+    @Override
     public void delete(Attendance attendance) {
         repository.delete(attendance);
     }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.QAttendance;
+import com.yanus.attendance.attendance.domain.attendance.QAttendance;
 import com.yanus.attendance.member.domain.QMember;
 import com.yanus.attendance.team.domain.QTeam;
 import java.time.LocalDate;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceQueryRepositoryImpl.java
@@ -2,8 +2,8 @@ package com.yanus.attendance.attendance.infrastructure;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.QAttendance;
 import com.yanus.attendance.member.domain.QMember;
 import com.yanus.attendance.team.domain.QTeam;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
@@ -16,4 +16,6 @@ public interface AttendanceSpringDataRepository extends JpaRepository<Attendance
     List<Attendance> findAllByWorkDate(LocalDate workDate);
 
     List<Attendance> findAllByWorkDateAndStatus(LocalDate workDate, AttendanceStatus status);
+
+    List<Attendance> findByMemberIdAndWorkDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/AttendanceSpringDataRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/JpaWorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/JpaWorkScheduleEventRepository.java
@@ -1,0 +1,37 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaWorkScheduleEventRepository implements WorkScheduleEventRepository {
+
+    private final WorkScheduleEventSpringDataRepository repository;
+
+    @Override
+    public WorkScheduleEvent save(WorkScheduleEvent event) { return repository.save(event); }
+
+    @Override
+    public Optional<WorkScheduleEvent> findById(Long id) { return repository.findById(id); }
+
+    @Override
+    public Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date) {
+        return repository.findByMemberIdAndDate(memberId, date);
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return repository.findAllByMemberIdAndDateBetween(memberId, start, end);
+    }
+
+    @Override
+    public void delete(WorkScheduleEvent event) {
+        repository.delete(event);
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleEventSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleEventSpringDataRepository.java
@@ -1,0 +1,15 @@
+package com.yanus.attendance.attendance.infrastructure;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkScheduleEventSpringDataRepository extends JpaRepository<WorkScheduleEvent, Long> {
+
+    Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date);
+
+    List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
+}
+

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleJpaRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/WorkScheduleSpringDataRepository.java
@@ -1,6 +1,6 @@
 package com.yanus.attendance.attendance.infrastructure;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation;
 
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import com.yanus.attendance.attendance.application.AttendanceService;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
@@ -53,6 +54,16 @@ public class AttendanceController {
             @RequestParam(required = false) String teamName
     ) {
         return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
+    }
+
+    @GetMapping("/range")
+    public ResponseEntity<ApiResponse<List<AttendanceRangeResponse>>> getAttendancesByRange(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam Long targetMemberId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(
+                attendanceService.getAttendancesByRange(memberId, targetMemberId, startDate, endDate)));
     }
 
     @DeleteMapping("/me")

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -9,8 +9,10 @@ import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,10 +49,25 @@ public class AttendanceController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<AttendanceResponse>>> getAttendancesByFilter(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate date,
             @RequestParam(required = false) String teamName
     ) {
         return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> resetAttendance(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
+        LocalDate targetDate = null;
+        if (date != null) {
+            targetDate = date;
+        }
+        if (date == null) {
+            targetDate = LocalDate.now();
+        }
+        attendanceService.resetAttendance(memberId, targetDate);
+        return ResponseEntity.noContent().build();
     }
 
     private String extractClientIp(HttpServletRequest request) {

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation;
 
+import jakarta.servlet.http.HttpServletRequest;
 import com.yanus.attendance.attendance.application.AttendanceService;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.response.ApiResponse;
@@ -26,8 +27,10 @@ public class AttendanceController {
 
     @PostMapping("/check-in")
     public ResponseEntity<ApiResponse<AttendanceResponse>> checkIn(
-            @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(ApiResponse.success(attendanceService.checkIn(memberId)));
+            @AuthenticationPrincipal Long memberId,
+            HttpServletRequest request) {
+        String ip = extractClientIp(request);
+        return ResponseEntity.ok(ApiResponse.success(attendanceService.checkIn(memberId, ip)));
     }
 
     @PostMapping("/check-out")
@@ -48,5 +51,13 @@ public class AttendanceController {
             @RequestParam(required = false) String teamName
     ) {
         return ResponseEntity.ok(ApiResponse.success(attendanceService.getAttendancesByFilter(date, teamName)));
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceSettlementController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/AttendanceSettlementController.java
@@ -1,0 +1,35 @@
+package com.yanus.attendance.attendance.presentation;
+
+import com.yanus.attendance.attendance.application.AttendanceSettlementService;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.YearMonth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "지각 정산", description = "월별 지각 정산 조회")
+@RestController
+@RequestMapping("/api/v1/attendance-settlements")
+@RequiredArgsConstructor
+public class AttendanceSettlementController {
+
+    private final AttendanceSettlementService settlementService;
+
+    @GetMapping("/monthly")
+    public ResponseEntity<ApiResponse<AttendanceSettlementResponse>> getMonthlySettlement(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam String yearMonth,
+            @RequestParam(required = false) Long targetMemberId) {
+
+        Long target = targetMemberId != null ? targetMemberId : memberId;
+
+        return ResponseEntity.ok(ApiResponse.success(
+                settlementService.getMonthlySettlement(memberId, target, YearMonth.parse(yearMonth))));
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
@@ -1,0 +1,63 @@
+package com.yanus.attendance.attendance.presentation;
+
+import com.yanus.attendance.attendance.application.WorkScheduleEventService;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "닐찌뱔 근무 일정", description = "특정 날짜 근무 일정 CRUD")
+@RestController
+@RequestMapping("/api/v1/work-schedule-events")
+@RequiredArgsConstructor
+public class WorkScheduleEventController {
+
+    private final WorkScheduleEventService workScheduleEventService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<WorkScheduleEventResponse>> createEvent(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody WorkScheduleEventRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.createEvent(memberId, request)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<WorkScheduleEventResponse>>> getEvents(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.getEvents(memberId, startDate, endDate)));
+    }
+
+    @PutMapping("/{eventId}")
+    public ResponseEntity<ApiResponse<WorkScheduleEventResponse>> updateEvent(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long eventId,
+            @RequestBody WorkScheduleEventRequest request) {
+        return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.updateEvent(memberId, eventId, request)));
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<Void> deleteEvent(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long eventId) {
+        workScheduleEventService.deleteEvent(memberId, eventId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/WorkScheduleEventController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "닐찌뱔 근무 일정", description = "특정 날짜 근무 일정 CRUD")
+@Tag(name = "닐짜별 근무 일정", description = "특정 날짜 근무 일정 CRUD")
 @RestController
 @RequestMapping("/api/v1/work-schedule-events")
 @RequiredArgsConstructor

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceRangeResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceRangeResponse.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.member.domain.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record AttendanceRangeResponse(
+        Long attendanceId,
+        Long memberId,
+        String memberName,
+        String teamName,
+        LocalDate workDate,
+        LocalDateTime checkInTime,
+        LocalDateTime checkOutTime,
+        AttendanceStatus status
+) {
+    public static AttendanceRangeResponse from(Attendance attendance) {
+        Member member = attendance.getMember();
+        return new AttendanceRangeResponse(
+                attendance.getId(),
+                member.getId(),
+                member.getName(),
+                member.getTeam() != null ? member.getTeam().getName() : null,
+                attendance.getWorkDate(),
+                attendance.getCheckInTime(),
+                attendance.getCheckOutTime(),
+                attendance.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceResponse.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementItemResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementItemResponse.java
@@ -1,0 +1,18 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record AttendanceSettlementItemResponse(
+        LocalDate date,
+        LocalTime scheduledStartTime,
+        LocalTime scheduledEndTime,
+        LocalDateTime checkInTime,
+        LocalDateTime checkOutTime,
+        int lateMinutes,
+        int fee,
+        AttendanceSettlementStatus status
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceSettlementResponse.java
@@ -1,0 +1,17 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.util.List;
+
+public record AttendanceSettlementResponse(
+        String yearMonth,
+        Long memberId,
+        String memberName,
+        String teamName,
+        int scheduledDays,
+        int attendedDays,
+        int lateDays,
+        int totalLateMinutes,
+        int lateFee,
+        List<AttendanceSettlementItemResponse> items
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventRequest.java
@@ -1,0 +1,11 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleEventRequest(
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleEventResponse.java
@@ -1,0 +1,27 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record WorkScheduleEventResponse(
+        Long id,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        Long memberId,
+        String memberName,
+        String teamName
+) {
+    public static WorkScheduleEventResponse from(WorkScheduleEvent event) {
+        return new WorkScheduleEventResponse(
+                event.getId(),
+                event.getDate(),
+                event.getStartTime(),
+                event.getEndTime(),
+                event.getMember().getId(),
+                event.getMember().getName(),
+                event.getMember().getTeam().getName()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
@@ -1,11 +1,13 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
+import com.yanus.attendance.attendance.domain.WeekPattern;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 
 public record WorkScheduleRequest(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
-        LocalTime endTime
+        LocalTime endTime,
+        WeekPattern weekPattern
 ) {
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleRequest.java
@@ -1,6 +1,6 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
-import com.yanus.attendance.attendance.domain.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
-import com.yanus.attendance.attendance.domain.WeekPattern;
-import com.yanus.attendance.attendance.domain.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/WorkScheduleResponse.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
+import com.yanus.attendance.attendance.domain.WeekPattern;
 import com.yanus.attendance.attendance.domain.WorkSchedule;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -8,14 +9,16 @@ public record WorkScheduleResponse(
         Long id,
         DayOfWeek dayOfWeek,
         LocalTime startTime,
-        LocalTime endTime
+        LocalTime endTime,
+        WeekPattern weekPattern
 ) {
     public static WorkScheduleResponse from(WorkSchedule schedule) {
         return new WorkScheduleResponse(
                 schedule.getId(),
                 schedule.getDayOfWeek(),
                 schedule.getStartTime(),
-                schedule.getEndTime()
+                schedule.getEndTime(),
+                schedule.getWeekPattern()
         );
     }
 }

--- a/src/main/java/com/yanus/attendance/audit/domain/AuditAction.java
+++ b/src/main/java/com/yanus/attendance/audit/domain/AuditAction.java
@@ -1,5 +1,5 @@
 package com.yanus.attendance.audit.domain;
 
 public enum AuditAction {
-    ROLE_CHANGE, TEAM_CHANGE, DEACTIVATE, ACTIVATE
+    ROLE_CHANGE, TEAM_CHANGE, DEACTIVATE, ACTIVATE, PASSWORD_RESET
 }

--- a/src/main/java/com/yanus/attendance/auth/application/AuthService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
                 request.email(),
                 passwordEncoder.encode(request.password()),
                 MemberRole.MEMBER,
-                MemberStatus.ACTIVE,
+                MemberStatus.PENDING,
                 team
         );
         memberRepository.save(member);
@@ -73,6 +73,10 @@ public class AuthService {
 
         if (member.isInactive()) {
             throw new BusinessException(ErrorCode.MEMBER_INACTIVE);
+        }
+
+        if (member.isPending()) {
+            throw new BusinessException(ErrorCode.MEMBER_PENDING);
         }
 
         member.recordLoginSuccess();

--- a/src/main/java/com/yanus/attendance/auth/application/AuthService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/AuthService.java
@@ -32,6 +32,7 @@ public class AuthService {
     private final TeamRepository teamRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
 
     @Transactional
     public void register(RegisterRequest request) {
@@ -50,7 +51,8 @@ public class AuthService {
                 MemberStatus.PENDING,
                 team
         );
-        memberRepository.save(member);
+        Member saved = memberRepository.save(member);
+        emailVerificationService.sendVerification(saved.getId(), saved.getEmail());
     }
 
     @Transactional

--- a/src/main/java/com/yanus/attendance/auth/application/EmailService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailService.java
@@ -1,0 +1,22 @@
+package com.yanus.attendance.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendVerificationEmail(String email, String verificationToken) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[yANUs] 이메일 인증을 완료해주세요");
+        message.setText("아래 토큰을 입력하여 이메일 인증을 완료하세요.\n\n토큰: " + verificationToken
+                + "\n\n토큰은 30분간 유효합니다.");
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
@@ -42,4 +42,10 @@ public class EmailVerificationService {
         verificationToken.use();
         member.activate();
     }
+
+    public void resend(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        sendVerification(member.getId(), member.getEmail());
+    }
 }

--- a/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
+++ b/src/main/java/com/yanus/attendance/auth/application/EmailVerificationService.java
@@ -1,0 +1,45 @@
+package com.yanus.attendance.auth.application;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EmailVerificationService {
+
+    private final EmailVerificationTokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+    private final EmailService emailService;
+
+    public void sendVerification(Long memberId, String email) {
+        tokenRepository.deleteByMemberId(memberId);
+        String token = UUID.randomUUID().toString();
+        tokenRepository.save(EmailVerificationToken.create(token, memberId, LocalDateTime.now().plusMinutes(30)));
+        emailService.sendVerificationEmail(email, token);
+    }
+
+    public void verify(String token) {
+        EmailVerificationToken verificationToken = tokenRepository.findByToken(token)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_VERIFICATION_TOKEN));
+
+        if (verificationToken.isExpired() || verificationToken.isUsed()) {
+            throw new BusinessException(ErrorCode.INVALID_VERIFICATION_TOKEN);
+        }
+
+        Member member = memberRepository.findById(verificationToken.getMemberId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        verificationToken.use();
+        member.activate();
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationToken.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationToken.java
@@ -1,0 +1,50 @@
+package com.yanus.attendance.auth.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerificationToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "token", nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private boolean used;
+
+    public static EmailVerificationToken create(String token, Long memberId, LocalDateTime expiresAt) {
+        EmailVerificationToken emailVerificationToken = new EmailVerificationToken();
+        emailVerificationToken.token = token;
+        emailVerificationToken.memberId = memberId;
+        emailVerificationToken.expiresAt = expiresAt;
+        emailVerificationToken.used = false;
+        return emailVerificationToken;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void use() {
+        this.used = true;
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
@@ -1,5 +1,7 @@
 package com.yanus.attendance.auth.domain;
 
+import java.util.Optional;
+
 public interface EmailVerificationTokenRepository {
     EmailVerificationToken save(EmailVerificationToken token);
     Optional<EmailVerificationToken> findByToken(String token);

--- a/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/domain/EmailVerificationTokenRepository.java
@@ -1,0 +1,7 @@
+package com.yanus.attendance.auth.domain;
+
+public interface EmailVerificationTokenRepository {
+    EmailVerificationToken save(EmailVerificationToken token);
+    Optional<EmailVerificationToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenJpaRepository.java
@@ -1,0 +1,29 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationTokenJpaRepository implements EmailVerificationTokenRepository {
+
+    private final EmailVerificationTokenSpringDataRepository repository;
+
+    @Override
+    public EmailVerificationToken save(EmailVerificationToken token) {
+        return repository.save(token);
+    }
+
+    @Override
+    public Optional<EmailVerificationToken> findByToken(String token) {
+        return repository.findByToken(token);
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        repository.deleteByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/EmailVerificationTokenSpringDataRepository.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailVerificationTokenSpringDataRepository extends JpaRepository<EmailVerificationToken, Long> {
+    Optional<EmailVerificationToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepository.java
@@ -28,7 +28,3 @@ public class RefreshTokenJpaRepository implements RefreshTokenRepository {
     }
 }
 
-interface RefreshTokenJpaRepositoryPort extends org.springframework.data.jpa.repository.JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByToken(String token);
-    void deleteByMemberId(Long memberId);
-}

--- a/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepositoryPort.java
+++ b/src/main/java/com/yanus/attendance/auth/infrastructure/RefreshTokenJpaRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.auth.infrastructure;
+
+import com.yanus.attendance.auth.domain.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenJpaRepositoryPort extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
@@ -1,12 +1,19 @@
 package com.yanus.attendance.auth.presentation;
 
 import com.yanus.attendance.auth.application.AuthService;
+import com.yanus.attendance.auth.application.EmailService;
+import com.yanus.attendance.auth.application.EmailVerificationService;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
 import com.yanus.attendance.auth.presentation.dto.LoginResponse;
 import com.yanus.attendance.auth.presentation.dto.MeResponse;
 import com.yanus.attendance.auth.presentation.dto.RefreshRequest;
 import com.yanus.attendance.auth.presentation.dto.RegisterRequest;
+import com.yanus.attendance.auth.presentation.dto.ResendVerificationRequest;
+import com.yanus.attendance.auth.presentation.dto.VerifyEmailRequest;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.global.response.ApiResponse;
+import com.yanus.attendance.member.domain.Member;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<Void>> register(@RequestBody RegisterRequest request) {
@@ -44,6 +52,18 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal Long memberId) {
         authService.logout(memberId);
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/verify-email")
+    public ResponseEntity<ApiResponse<Void>> verifyEmail(@RequestBody VerifyEmailRequest request) {
+        emailVerificationService.verify(request.token());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/verify-email/resend")
+    public ResponseEntity<ApiResponse<Void>> resendVerification(@RequestBody ResendVerificationRequest request) {
+        emailVerificationService.resend(request.email());
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/AuthController.java
@@ -1,7 +1,6 @@
 package com.yanus.attendance.auth.presentation;
 
 import com.yanus.attendance.auth.application.AuthService;
-import com.yanus.attendance.auth.application.EmailService;
 import com.yanus.attendance.auth.application.EmailVerificationService;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
 import com.yanus.attendance.auth.presentation.dto.LoginResponse;
@@ -10,10 +9,7 @@ import com.yanus.attendance.auth.presentation.dto.RefreshRequest;
 import com.yanus.attendance.auth.presentation.dto.RegisterRequest;
 import com.yanus.attendance.auth.presentation.dto.ResendVerificationRequest;
 import com.yanus.attendance.auth.presentation.dto.VerifyEmailRequest;
-import com.yanus.attendance.global.exception.BusinessException;
-import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.global.response.ApiResponse;
-import com.yanus.attendance.member.domain.Member;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/yanus/attendance/auth/presentation/dto/ResendVerificationRequest.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/dto/ResendVerificationRequest.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.auth.presentation.dto;
+
+public record ResendVerificationRequest(
+        String email
+) {
+}

--- a/src/main/java/com/yanus/attendance/auth/presentation/dto/VerifyEmailRequest.java
+++ b/src/main/java/com/yanus/attendance/auth/presentation/dto/VerifyEmailRequest.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.auth.presentation.dto;
+
+public record VerifyEmailRequest(
+        String token
+) {
+}

--- a/src/main/java/com/yanus/attendance/global/config/SecurityConfig.java
+++ b/src/main/java/com/yanus/attendance/global/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/verify-email").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/verify-email/resend").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", "Refresh Token이 존재하지 않습니다."),
     TOKEN_REUSED(HttpStatus.UNAUTHORIZED, "TOKEN_REUSED", "이미 사용된 토큰입니다. 재로그인이 필요합니다."),
     ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "ACCOUNT_LOCKED", "로그인 시도 횟수를 초과하여 계정이 잠겼습니다. 30분 후 재시도해주세요."),
+    INVALID_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_VERIFICATION_TOKEN", "유효하지 않은 인증 토큰입니다."),
+    EXPIRED_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "EXPIRED_VERIFICATION_TOKEN", "만료된 인증 토큰입니다."),
+
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_NOT_FOUND", "존재하지 않는 회원입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "EMAIL_ALREADY_EXISTS", "이미 사용 중인 이메일입니다."),
     MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER_INACTIVE", "비활성화된 계정입니다."),
+    MEMBER_PENDING(HttpStatus.FORBIDDEN, "MEMBER_PENDING", "이메일 인증되지 않은 계정입니다."),
 
     // Attendance
     ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "ALREADY_CHECKED_IN", "이미 출근 처리되었습니다."),

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "ATTENDANCE_NOT_FOUND", "출근 기록을 찾을 수 없습니다."),
     INVALID_WORK_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_WORK_SCHEDULE_TIME", "종료 시간은 시작 시간 이후여야 합니다."),
     WORK_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORK_SCHEDULE_NOT_FOUND", "근무 일정을 찾을 수 없습니다."),
+    INVALID_ATTENDANCE_IP(HttpStatus.FORBIDDEN, "INVALID_ATTENDANCE_IP", "허용되지 않은 네트워크에서의 출근 요청입니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", "존재하지 않는 팀입니다."),

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_WORK_SCHEDULE_TIME(HttpStatus.BAD_REQUEST, "INVALID_WORK_SCHEDULE_TIME", "종료 시간은 시작 시간 이후여야 합니다."),
     WORK_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "WORK_SCHEDULE_NOT_FOUND", "근무 일정을 찾을 수 없습니다."),
     INVALID_ATTENDANCE_IP(HttpStatus.FORBIDDEN, "INVALID_ATTENDANCE_IP", "허용되지 않은 네트워크에서의 출근 요청입니다."),
+    WORK_SCHEDULE_EVENT_DUPLICATE(HttpStatus.CONFLICT, "WORK_SCHEDULE_EVENT_DUPLICATE", "해당 날짜에 이미 근무 일정이 존재합니다."),
 
     // Team
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND", "존재하지 않는 팀입니다."),

--- a/src/main/java/com/yanus/attendance/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yanus/attendance/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.global.exception;
 
 import com.yanus.attendance.global.response.ApiResponse;
+import java.time.format.DateTimeParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -38,5 +39,16 @@ public class GlobalExceptionHandler {
                         ErrorCode.INTERNAL_ERROR.getCode(),
                         ErrorCode.INTERNAL_ERROR.getMessage(),
                         null));
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDateTimeParseException(DateTimeParseException e) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ApiResponse<>(
+                        ErrorCode.BAD_REQUEST.getCode(),
+                        "yearMonth는 yyyy-MM 형식이어야 합니다",
+                        null
+                ));
     }
 }

--- a/src/main/java/com/yanus/attendance/member/application/MemberService.java
+++ b/src/main/java/com/yanus/attendance/member/application/MemberService.java
@@ -105,6 +105,7 @@ public class MemberService {
         Member target = memberRepository.findById(targetId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         String temporaryPassword = generateTemporaryPassword();
+        validateAdmin(actorId);
         target.updateProfile(null, temporaryPassword, passwordEncoder);
         auditLogService.log(actorId, actor.getRole(), targetId,
                 AuditAction.PASSWORD_RESET, null, null);

--- a/src/main/java/com/yanus/attendance/member/application/MemberService.java
+++ b/src/main/java/com/yanus/attendance/member/application/MemberService.java
@@ -11,6 +11,7 @@ import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import com.yanus.attendance.team.domain.Team;
 import com.yanus.attendance.team.domain.TeamRepository;
 import java.util.List;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.security.SecureRandom;
 
 @Service
 @RequiredArgsConstructor
@@ -96,6 +98,19 @@ public class MemberService {
                 AuditAction.TEAM_CHANGE, previousTeam, team.getName());
     }
 
+    @Transactional
+    public TemporaryPasswordResponse resetPassword(Long actorId, Long targetId) {
+        Member actor = memberRepository.findById(actorId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        Member target = memberRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+        String temporaryPassword = generateTemporaryPassword();
+        target.updateProfile(null, temporaryPassword, passwordEncoder);
+        auditLogService.log(actorId, actor.getRole(), targetId,
+                AuditAction.PASSWORD_RESET, null, null);
+        return new TemporaryPasswordResponse(temporaryPassword);
+    }
+
     private Member validateAdmin(Long actorId) {
         Member actor = memberRepository.findById(actorId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
@@ -115,5 +130,15 @@ public class MemberService {
             return;
         }
         throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+
+    private String generateTemporaryPassword() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(8);
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/yanus/attendance/member/domain/Member.java
+++ b/src/main/java/com/yanus/attendance/member/domain/Member.java
@@ -115,4 +115,8 @@ public class Member {
     public void changeTeam(Team team) {
         this.team = team;
     }
+
+    public boolean isPending() {
+        return this.status == MemberStatus.PENDING;
+    }
 }

--- a/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
 import com.yanus.attendance.member.presentation.dto.TeamChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -76,6 +78,13 @@ public class MemberController {
             @RequestBody TeamChangeRequest request) {
         memberService.changeTeam(actorId, memberId, request.teamId());
         return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @PostMapping("/{memberId}/reset-password")
+    public ResponseEntity<ApiResponse<TemporaryPasswordResponse>> resetPassword(
+            @AuthenticationPrincipal Long actorId,
+            @PathVariable Long memberId) {
+        return ResponseEntity.ok(ApiResponse.success(memberService.resetPassword(actorId, memberId)));
     }
 
     @PutMapping("/me")

--- a/src/main/java/com/yanus/attendance/member/presentation/dto/TemporaryPasswordResponse.java
+++ b/src/main/java/com/yanus/attendance/member/presentation/dto/TemporaryPasswordResponse.java
@@ -1,0 +1,6 @@
+package com.yanus.attendance.member.presentation.dto;
+
+public record TemporaryPasswordResponse(
+        String temporaryPassword
+) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,13 @@ minio.endpoint=${MINIO_ENDPOINT}
 minio.access-key=${MINIO_ACCESS_KEY}
 minio.secret-key=${MINIO_SECRET_KEY}
 minio.bucket=${MINIO_BUCKET:yanus-files}
+
+# =====================
+# Mail
+# =====================
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/db/migration/V16__add_work_schedule_week_pattern.sql
+++ b/src/main/resources/db/migration/V16__add_work_schedule_week_pattern.sql
@@ -1,0 +1,2 @@
+ALTER TABLE work_schedule
+    ADD COLUMN week_pattern VARCHAR(20) NOT NULL DEFAULT 'EVERY';

--- a/src/main/resources/db/migration/V17__create_work_schedule_event.sql
+++ b/src/main/resources/db/migration/V17__create_work_schedule_event.sql
@@ -1,0 +1,10 @@
+CREATE TABLE work_schedule_event (
+                                     work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                                     member_id   BIGINT    NOT NULL,
+                                     date        DATE      NOT NULL,
+                                     start_time  TIME      NOT NULL,
+                                     end_time    TIME      NOT NULL,
+                                     created_at  TIMESTAMP NOT NULL,
+                                     FOREIGN KEY (member_id) REFERENCES member(member_id),
+                                     UNIQUE (member_id, date)
+);

--- a/src/main/resources/db/migration/V17__create_work_schedule_event.sql
+++ b/src/main/resources/db/migration/V17__create_work_schedule_event.sql
@@ -1,10 +1,10 @@
 CREATE TABLE work_schedule_event (
-                                     work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-                                     member_id   BIGINT    NOT NULL,
-                                     date        DATE      NOT NULL,
-                                     start_time  TIME      NOT NULL,
-                                     end_time    TIME      NOT NULL,
-                                     created_at  TIMESTAMP NOT NULL,
-                                     FOREIGN KEY (member_id) REFERENCES member(member_id),
-                                     UNIQUE (member_id, date)
+    work_schedule_event_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    member_id   BIGINT    NOT NULL,
+    date        DATE      NOT NULL,
+    start_time  TIME      NOT NULL,
+    end_time    TIME      NOT NULL,
+    created_at  TIMESTAMP NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member(member_id),
+    UNIQUE (member_id, date)
 );

--- a/src/main/resources/db/migration/V18__create_email_verification_token.sql
+++ b/src/main/resources/db/migration/V18__create_email_verification_token.sql
@@ -1,0 +1,8 @@
+CREATE TABLE email_verification_token (
+    id          BIGSERIAL PRIMARY KEY,
+    token       VARCHAR(64) NOT NULL UNIQUE,
+    member_id   BIGINT      NOT NULL REFERENCES member(id),
+    expires_at  TIMESTAMP   NOT NULL,
+    used        BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMP   NOT NULL DEFAULT now()
+);

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceQueryRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import java.time.LocalDate;
 import java.util.List;
 

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -58,4 +58,14 @@ public class FakeAttendanceRepository implements AttendanceRepository {
     public void delete(Attendance attendance) {
         store.remove(attendance.getId());
     }
+
+    @Override
+    public List<Attendance> findByMemberIdAndWorkDateBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate) {
+        return store.values().stream()
+                .filter(a -> a.getMember().getId().equals(memberId))
+                .filter(a -> !a.getWorkDate().isBefore(startDate))
+                .filter(a -> !a.getWorkDate().isAfter(endDate))
+                .toList();
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -1,8 +1,8 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.Attendance;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceRepository.java
@@ -53,4 +53,9 @@ public class FakeAttendanceRepository implements AttendanceRepository {
                 .filter(a -> a.getStatus() == status)
                 .toList();
     }
+
+    @Override
+    public void delete(Attendance attendance) {
+        store.remove(attendance.getId());
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
@@ -1,0 +1,49 @@
+package com.yanus.attendance.attendance;
+
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeWorkScheduleEventRepository implements WorkScheduleEventRepository {
+
+    private final Map<Long, WorkScheduleEvent> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public WorkScheduleEvent save(WorkScheduleEvent event) {
+        if (event.getId() == null) ReflectionTestUtils.setField(event, "id", sequence++);
+        store.put(event.getId(), event);
+        return event;
+    }
+
+    @Override
+    public Optional<WorkScheduleEvent> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getId().equals(memberId) && e.getDate().equals(date))
+                .findFirst();
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getId().equals(memberId))
+                .filter(e -> !e.getDate().isBefore(start) && !e.getDate().isAfter(end))
+                .toList();
+    }
+
+    @Override
+    public void delete(WorkScheduleEvent event) {
+        store.remove(event.getId());
+    }
+}
+

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleRepository.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance;
 
-import com.yanus.attendance.attendance.domain.WorkSchedule;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import java.time.DayOfWeek;
 import java.util.HashMap;
 import java.util.List;

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -184,5 +184,5 @@ public class AttendanceServiceTest {
         // when & then
         assertThatThrownBy(() -> attendanceService.checkIn(member.getId(), "220.32.1.1"))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_LOCKED);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ATTENDANCE_IP);
     }}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -185,4 +185,31 @@ public class AttendanceServiceTest {
         assertThatThrownBy(() -> attendanceService.checkIn(member.getId(), "220.32.1.1"))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ATTENDANCE_IP);
-    }}
+    }
+
+    @Test
+    @DisplayName("오늘 출근 기록 초기화 성공")
+    void reset_attendance_success() {
+        // given
+        Member member = createMember();
+        attendanceService.checkIn(member.getId(), "220.69.1.1");
+
+        // when
+        attendanceService.resetAttendance(member.getId(), LocalDate.now());
+
+        // then
+        assertThat(attendanceService.getMyAttendances(member.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("출근 기록 없을 때 초기화 시 ATTENDANCE_NOT_FOUND 예외")
+    void reset_attendance_not_found_error() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.resetAttendance(member.getId(), LocalDate.now()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ATTENDANCE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -249,7 +249,7 @@ public class AttendanceServiceTest {
 
         // when
         List<AttendanceRangeResponse> result = attendanceService.getAttendancesByRange(
-                member, member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+                member.getId(), member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
 
         // then
         assertThat(result).hasSize(1);
@@ -267,7 +267,7 @@ public class AttendanceServiceTest {
         // when & then
         assertThatNoException().isThrownBy(() ->
                 attendanceService.getAttendancesByRange(
-                        leader, target.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)));
+                        leader.getId(), target.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)));
     }
 
     @Test
@@ -282,7 +282,7 @@ public class AttendanceServiceTest {
         // when & then
         assertThatThrownBy(() ->
                 attendanceService.getAttendancesByRange(
-                        leader, other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                        leader.getId(), other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
                 .isInstanceOf(BusinessException.class);
     }
 
@@ -296,7 +296,7 @@ public class AttendanceServiceTest {
         // when & then
         assertThatThrownBy(() ->
                 attendanceService.getAttendancesByRange(
-                        me, other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                        me.getId(), other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
                 .isInstanceOf(BusinessException.class);
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -1,9 +1,8 @@
 package com.yanus.attendance.attendance.application;
 
-import static com.yanus.attendance.task.domain.Task.createTeam;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.given;
 
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
@@ -11,6 +10,7 @@ import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
@@ -23,6 +23,7 @@ import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,8 +33,10 @@ public class AttendanceServiceTest {
 
     private AttendanceService attendanceService;
     private AttendanceRepository attendanceRepository;
-    private AttendanceQueryRepository attendanceQueryRepository;
     private MemberRepository memberRepository;
+
+    private final AtomicLong memberEmailSeq = new AtomicLong(1);
+    private final AtomicLong teamIdSeq = new AtomicLong(1);
 
     @BeforeEach
     void setUp() {
@@ -41,14 +44,34 @@ public class AttendanceServiceTest {
         memberRepository = new FakeMemberRepository();
         AttendanceQueryRepository attendanceQueryRepository = new FakeAttendanceQueryRepository(attendanceRepository);
         attendanceService = new AttendanceService(attendanceRepository, memberRepository, attendanceQueryRepository);
+        memberEmailSeq.set(1);
+        teamIdSeq.set(1);
     }
 
     private Member createMember() {
+        return createMember(MemberRole.ADMIN);
+    }
+
+    private Member createMember(MemberRole role) {
         Team team = Team.create("1팀");
         ReflectionTestUtils.setField(team, "id", 1L);
-        Member member = Member.create("정용태", "jyt6640@naver.com", "password123", MemberRole.ADMIN, MemberStatus.ACTIVE, team);
+        String email = "user" + memberEmailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("정용태", email, "password123", role, MemberStatus.ACTIVE, team);
         return memberRepository.save(member);
     }
+
+    private Member createMemberWithTeam(MemberRole role, Team team) {
+        String email = "user" + memberEmailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("멤버", email, "password123", role, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    private Team createTeam(String name) {
+        Team team = Team.create(name);
+        ReflectionTestUtils.setField(team, "id", teamIdSeq.getAndIncrement());
+        return team;
+    }
+
 
     @Test
     @DisplayName("출근 체크인 시 WORKING 상태로 저장")
@@ -221,10 +244,8 @@ public class AttendanceServiceTest {
     void get_attendances_by_range() {
         // given
         Member member = createMember(MemberRole.MEMBER);
-        Attendance attendance = createAttendance(member, LocalDate.of(2026, 3, 4));
-        given(attendanceRepository.findByMemberIdAndWorkDateBetween(
-                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
-                .willReturn(List.of(attendance));
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 0, 0));
+        attendanceRepository.save(attendance);
 
         // when
         List<AttendanceRangeResponse> result = attendanceService.getAttendancesByRange(
@@ -236,15 +257,12 @@ public class AttendanceServiceTest {
     }
 
     @Test
-    @DisplayName("팀장은 같은 팀 멤버 출근 내역 조회")
+    @DisplayName("팀장은 같은 팀 멤버 출근 내역 조회 가능")
     void team_lead_can_get_attendances_by_range() {
         // given
-        Team team = createTeam();
+        Team team = createTeam("1팀");
         Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, team);
         Member target = createMemberWithTeam(MemberRole.MEMBER, team);
-        given(memberRepository.findById(target.getId())).willReturn(Optional.of(target));
-        given(attendanceRepository.findByMemberIdAndWorkDateBetween(any(), any(), any()))
-                .willReturn(List.of());
 
         // when & then
         assertThatNoException().isThrownBy(() ->
@@ -256,9 +274,10 @@ public class AttendanceServiceTest {
     @DisplayName("팀장은 다른 팀 멤버 출근 내역 조회 불가")
     void team_lead_cannot_get_attendances_by_range() {
         // given
-        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, createTeam());
-        Member other = createMemberWithTeam(MemberRole.MEMBER, createTeam());
-        given(memberRepository.findById(other.getId())).willReturn(Optional.of(other));
+        Team myTeam = createTeam("1팀");
+        Team otherTeam = createTeam("2팀");
+        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, myTeam);
+        Member other = createMemberWithTeam(MemberRole.MEMBER, otherTeam);
 
         // when & then
         assertThatThrownBy(() ->
@@ -273,7 +292,6 @@ public class AttendanceServiceTest {
         // given
         Member me = createMember(MemberRole.MEMBER);
         Member other = createMember(MemberRole.MEMBER);
-        given(memberRepository.findById(other.getId())).willReturn(Optional.of(other));
 
         // when & then
         assertThatThrownBy(() ->
@@ -281,5 +299,4 @@ public class AttendanceServiceTest {
                         me, other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
                 .isInstanceOf(BusinessException.class);
     }
-
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -10,6 +10,7 @@ import com.yanus.attendance.attendance.domain.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
@@ -160,4 +161,28 @@ public class AttendanceServiceTest {
         assertThat(responses.get(0).status()).isEqualTo(AttendanceStatus.LEFT);
         assertThat(responses.get(0).checkOutTime()).isEqualTo(date.atTime(23, 59, 59));
     }
-}
+
+    @Test
+    @DisplayName("허용된 IP로 체크인 성공")
+    void check_in_with_allowed_ip() {
+        // given
+        Member member = createMember();
+
+        // when
+        AttendanceResponse response = attendanceService.checkIn(member.getId(), "220.69.1.1");
+
+        // then
+        assertThat(response.status()).isEqualTo(AttendanceStatus.WORKING);
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 IP로 체크인 시 예외 발생")
+    void check_in_with_not_allowed_ip() {
+        // given
+        Member member = createMember();
+
+        // when & then
+        assertThatThrownBy(() -> attendanceService.checkIn(member.getId(), "220.32.1.1"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_LOCKED);
+    }}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -1,10 +1,13 @@
 package com.yanus.attendance.attendance.application;
 
+import static com.yanus.attendance.task.domain.Task.createTeam;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.given;
 
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
@@ -212,4 +215,71 @@ public class AttendanceServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ATTENDANCE_NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("기간별 출근 내역 본인 조회")
+    void get_attendances_by_range() {
+        // given
+        Member member = createMember(MemberRole.MEMBER);
+        Attendance attendance = createAttendance(member, LocalDate.of(2026, 3, 4));
+        given(attendanceRepository.findByMemberIdAndWorkDateBetween(
+                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .willReturn(List.of(attendance));
+
+        // when
+        List<AttendanceRangeResponse> result = attendanceService.getAttendancesByRange(
+                member, member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).workDate()).isEqualTo(LocalDate.of(2026, 3, 4));
+    }
+
+    @Test
+    @DisplayName("팀장은 같은 팀 멤버 출근 내역 조회")
+    void team_lead_can_get_attendances_by_range() {
+        // given
+        Team team = createTeam();
+        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, team);
+        Member target = createMemberWithTeam(MemberRole.MEMBER, team);
+        given(memberRepository.findById(target.getId())).willReturn(Optional.of(target));
+        given(attendanceRepository.findByMemberIdAndWorkDateBetween(any(), any(), any()))
+                .willReturn(List.of());
+
+        // when & then
+        assertThatNoException().isThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        leader, target.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)));
+    }
+
+    @Test
+    @DisplayName("팀장은 다른 팀 멤버 출근 내역 조회 불가")
+    void team_lead_cannot_get_attendances_by_range() {
+        // given
+        Member leader = createMemberWithTeam(MemberRole.TEAM_LEAD, createTeam());
+        Member other = createMemberWithTeam(MemberRole.MEMBER, createTeam());
+        given(memberRepository.findById(other.getId())).willReturn(Optional.of(other));
+
+        // when & then
+        assertThatThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        leader, other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("멤버가 타인 출근 내역 조회 시 예외")
+    void member_cannot_get_attendances_by_range() {
+        // given
+        Member me = createMember(MemberRole.MEMBER);
+        Member other = createMember(MemberRole.MEMBER);
+        given(memberRepository.findById(other.getId())).willReturn(Optional.of(other));
+
+        // when & then
+        assertThatThrownBy(() ->
+                attendanceService.getAttendancesByRange(
+                        me, other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .isInstanceOf(BusinessException.class);
+    }
+
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -5,9 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceQueryRepository;
-import com.yanus.attendance.attendance.domain.AttendanceRepository;
-import com.yanus.attendance.attendance.domain.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -1,0 +1,213 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleEventRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementItemResponse;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceSettlementResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class AttendanceSettlementServiceTest {
+
+    private AttendanceSettlementService settlementService;
+    private AttendanceRepository attendanceRepository;
+    private WorkScheduleRepository workScheduleRepository;
+    private WorkScheduleEventRepository workScheduleEventRepository;
+    private MemberRepository memberRepository;
+
+    private final AtomicLong emailSeq = new AtomicLong(1);
+
+    @BeforeEach
+    void setUp() {
+        attendanceRepository = new FakeAttendanceRepository();
+        workScheduleRepository = new FakeWorkScheduleRepository();
+        workScheduleEventRepository = new FakeWorkScheduleEventRepository();
+        memberRepository = new FakeMemberRepository();
+        settlementService = new AttendanceSettlementService(
+                attendanceRepository, workScheduleRepository,
+                workScheduleEventRepository, memberRepository);
+        emailSeq.set(1);
+    }
+
+    private Member createMember(MemberRole role) {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        String email = "user" + emailSeq.getAndIncrement() + "@test.com";
+        Member member = Member.create("정용태", email, "password123", role, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    private AttendanceSettlementItemResponse findItem(AttendanceSettlementResponse response, LocalDate date) {
+        return response.items().stream()
+                .filter(i -> i.date().equals(date))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @Test
+    @DisplayName("정시 출근은 ON_TIME이고 지각비 0원")
+    void 정시_출근은_ON_TIME이고_지각비_0원() {
+        // given - 2026-03-04 (수요일)
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 8, 55, 0));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.ON_TIME);
+        assertThat(item.lateMinutes()).isZero();
+        assertThat(item.fee()).isZero();
+    }
+
+    @Test
+    @DisplayName("지각 7분 59초는 7분으로 계산하고 700원")
+    void 지각_7분_59초는_7분으로_계산하고_700원() {
+        // given - 2026-03-04 (수요일)
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 7, 59));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.LATE);
+        assertThat(item.lateMinutes()).isEqualTo(7);
+        assertThat(item.fee()).isEqualTo(700);
+    }
+
+    @Test
+    @DisplayName("WorkScheduleEvent가 있으면 반복 일정보다 우선 적용")
+    void WorkScheduleEvent가_있으면_반복_일정보다_우선_적용() {
+        // given - 반복 일정 09:00, 이벤트로 10:00 오버라이드, 10:05 출근
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        WorkScheduleEvent event = WorkScheduleEvent.create(member,
+                LocalDate.of(2026, 3, 4), LocalTime.of(10, 0), LocalTime.of(19, 0));
+        workScheduleEventRepository.save(event);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 10, 5, 0));
+        attendanceRepository.save(attendance);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then - 이벤트 기준 10:00 대비 5분 지각
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.scheduledStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(item.lateMinutes()).isEqualTo(5);
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.LATE);
+    }
+
+    @Test
+    @DisplayName("근무 일정 없는 날은 items에 포함되지 않는다")
+    void 근무_일정_없는_날은_items에_포함되지_않는다() {
+        // given - 근무 일정 없음
+        Member member = createMember(MemberRole.MEMBER);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        assertThat(result.items()).isEmpty();
+        assertThat(result.scheduledDays()).isZero();
+    }
+
+    @Test
+    @DisplayName("출근 기록 없는 날은 ABSENT이고 지각비 없음")
+    void 출근_기록_없는_날은_ABSENT이고_지각비_없음() {
+        // given - 일정은 있고 출근 기록 없음
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        AttendanceSettlementItemResponse item = findItem(result, LocalDate.of(2026, 3, 4));
+        assertThat(item.status()).isEqualTo(AttendanceSettlementStatus.ABSENT);
+        assertThat(item.fee()).isZero();
+        assertThat(result.lateFee()).isZero();
+    }
+
+    @Test
+    @DisplayName("월별 집계 정상 계산")
+    void 월별_집계_정상_계산() {
+        // given - 3/4 (수) 10분 지각, 3/11 (수) 정시 출근
+        Member member = createMember(MemberRole.MEMBER);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        workScheduleRepository.save(schedule);
+        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 10, 0)));
+        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 11, 9, 0, 0)));
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 3));
+
+        // then
+        assertThat(result.lateDays()).isEqualTo(1);
+        assertThat(result.totalLateMinutes()).isEqualTo(10);
+        assertThat(result.lateFee()).isEqualTo(1000);
+        assertThat(result.attendedDays()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("MEMBER가 타인 정산 조회 시 예외")
+    void MEMBER가_타인_정산_조회_시_예외() {
+        // given
+        Member me = createMember(MemberRole.MEMBER);
+        Member other = createMember(MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() ->
+                settlementService.getMonthlySettlement(
+                        me.getId(), other.getId(), YearMonth.of(2026, 3)))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
@@ -3,6 +3,9 @@ package com.yanus.attendance.attendance.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.FakeWorkScheduleEventRepository;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventRequest;
+import com.yanus.attendance.attendance.presentation.dto.WorkScheduleEventResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
@@ -13,6 +16,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
@@ -1,0 +1,121 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class WorkScheduleEventServiceTest {
+
+    private WorkScheduleEventService workScheduleEventService;
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = new FakeMemberRepository();
+        workScheduleEventService = new WorkScheduleEventService(new FakeWorkScheduleEventRepository(), memberRepository);
+    }
+
+    private Member createMember() {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("테스터", "test@test.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("날짜별 근무 일정 생성 성공")
+    void create_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventRequest request = new WorkScheduleEventRequest(
+                LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0));
+
+        // when
+        WorkScheduleEventResponse response = workScheduleEventService.createEvent(member.getId(), request);
+
+        // then
+        assertThat(response.date()).isEqualTo(LocalDate.of(2026, 3, 30));
+        assertThat(response.startTime()).isEqualTo(LocalTime.of(9, 0));
+    }
+
+    @Test
+    @DisplayName("같은 날짜 중복 일정 생성 시 예외")
+    void create_duplicate_event_error() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventRequest request = new WorkScheduleEventRequest(
+                LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0));
+        workScheduleEventService.createEvent(member.getId(), request);
+
+        // when & then
+        assertThatThrownBy(() -> workScheduleEventService.createEvent(member.getId(), request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.WORK_SCHEDULE_EVENT_DUPLICATE);
+    }
+
+    @Test
+    @DisplayName("기간 내 날짜별 일정 조회")
+    void get_events_by_period() {
+        // given
+        Member member = createMember();
+        workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 10), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+        workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 20), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getEvents(
+                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("날짜별 일정 수정 성공")
+    void update_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventResponse created = workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        WorkScheduleEventResponse updated = workScheduleEventService.updateEvent(
+                member.getId(), created.id(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(10, 0), LocalTime.of(19, 0)));
+
+        // then
+        assertThat(updated.startTime()).isEqualTo(LocalTime.of(10, 0));
+    }
+
+    @Test
+    @DisplayName("날짜별 일정 삭제 성공")
+    void delete_event_success() {
+        // given
+        Member member = createMember();
+        WorkScheduleEventResponse created = workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 30), LocalTime.of(9, 0), LocalTime.of(18, 0)));
+
+        // when
+        workScheduleEventService.deleteEvent(member.getId(), created.id());
+
+        // then
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getEvents(
+                member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+        assertThat(responses).isEmpty();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.WeekPattern;
 import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
@@ -53,7 +54,8 @@ public class WorkScheduleServiceTest {
     void set_work_schedule() {
         // given
         Member member = create();
-        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0));
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0),
+                WeekPattern.EVERY);
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
@@ -70,11 +72,11 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // then
         assertThat(response.startTime()).isEqualTo(LocalTime.of(10, 0));
@@ -87,9 +89,9 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<WorkScheduleResponse> responses = workScheduleService.getMyWorkSchedules(member.getId());
@@ -104,7 +106,7 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         workScheduleService.deleteWorkSchedule(member.getId(), DayOfWeek.MONDAY);
@@ -134,9 +136,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, member1.getTeam()));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.TUESDAY, LocalTime.of(10, 0), LocalTime.of(19, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -157,9 +159,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team2));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.WEDNESDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(member1.getId());
@@ -186,7 +188,7 @@ public class WorkScheduleServiceTest {
         // given
         Member admin = createMember("1팀", MemberRole.ADMIN);
         workScheduleService.setWorkSchedule(admin.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(admin.getId());
@@ -201,7 +203,7 @@ public class WorkScheduleServiceTest {
         // given
         Member teamLead = createMember("1팀", MemberRole.TEAM_LEAD);
         workScheduleService.setWorkSchedule(teamLead.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0)));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -227,18 +227,6 @@ public class WorkScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("MEMBER가 팀 근무 일정 조회 시 예외 발생")
-    void member_get_team_work_schedules_forbidden() {
-        // given
-        Member member = createMember("1팀", MemberRole.MEMBER);
-
-        // when & then
-        assertThatThrownBy(() -> workScheduleService.getTeamWorkSchedules(member.getId(), member.getTeam().getId()))
-                .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
-    }
-
-    @Test
     @DisplayName("weekPattern FIRST로 등록 후 조회 시 FIRST 반환")
     void set_work_schedule_with_week_pattern() {
         // given

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
-import com.yanus.attendance.attendance.domain.WeekPattern;
-import com.yanus.attendance.attendance.domain.WorkScheduleRepository;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleRequest;
 import com.yanus.attendance.attendance.presentation.dto.WorkScheduleResponse;

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -76,7 +76,7 @@ public class WorkScheduleServiceTest {
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // then
         assertThat(response.startTime()).isEqualTo(LocalTime.of(10, 0));
@@ -91,7 +91,7 @@ public class WorkScheduleServiceTest {
         workScheduleService.setWorkSchedule(member.getId(),
                 new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+                new WorkScheduleRequest(DayOfWeek.THURSDAY, LocalTime.of(9, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // when
         List<WorkScheduleResponse> responses = workScheduleService.getMyWorkSchedules(member.getId());
@@ -266,4 +266,32 @@ public class WorkScheduleServiceTest {
         assertThat(response.weekPattern()).isEqualTo(WeekPattern.EVERY);
     }
 
+    @Test
+    @DisplayName("같은 팀 MEMBER가 팀 근무 일정 조회 성공")
+    void member_get_own_team_work_schedules_success() {
+        // given
+        Member member = createMember("1팀", MemberRole.MEMBER);
+        workScheduleService.setWorkSchedule(member.getId(),
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+
+        // when
+        List<MemberWorkScheduleResponse> responses =
+                workScheduleService.getTeamWorkSchedules(member.getId(), member.getTeam().getId());
+
+        // then
+        assertThat(responses).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("다른 팀 MEMBER가 팀 근무 일정 조회 시 FORBIDDEN")
+    void member_get_other_team_work_schedules_forbidden() {
+        // given
+        Member member = createMember("1팀", MemberRole.MEMBER);
+        Member otherMember = createMember("2팀", MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() -> workScheduleService.getTeamWorkSchedules(member.getId(), otherMember.getTeam().getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -235,4 +235,33 @@ public class WorkScheduleServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
     }
+
+    @Test
+    @DisplayName("weekPattern FIRST로 등록 후 조회 시 FIRST 반환")
+    void set_work_schedule_with_week_pattern() {
+        // given
+        Member member = create();
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.FIRST);
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
+
+        // then
+        assertThat(response.weekPattern()).isEqualTo(WeekPattern.FIRST);
+    }
+
+    @Test
+    @DisplayName("weekPattern null로 등록 시 기본값 EVERY")
+    void set_work_schedule_default_week_pattern() {
+        // given
+        Member member = create();
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), null);
+
+        // when
+        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
+
+        // then
+        assertThat(response.weekPattern()).isEqualTo(WeekPattern.EVERY);
+    }
+
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
@@ -1,0 +1,62 @@
+package com.yanus.attendance.attendance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AttendanceSettlementCalculatorTest {
+
+    @Test
+    @DisplayName("정시 출근시 요금 0원")
+    void regular_check_in_is_free() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 9, 0, 0);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isZero();
+    }
+
+    @Test
+    void fifteen_nine_minutes_after_scheduled_time_is_late() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 9, 7, 59);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("지각비는 분당 백원")
+    void late_fee_is_per_minute() {
+        // when
+        int fee = AttendanceSettlementCalculator.calculateFee(27);
+
+        // then
+        assertThat(fee).isEqualTo(2700);
+    }
+
+    @Test
+    @DisplayName("조기 출근은 지각비 0원")
+    void early_check_in_is_free() {
+        // given
+        LocalTime scheduled = LocalTime.of(9, 0);
+        LocalDateTime checkIn = LocalDateTime.of(2026, 3, 4, 8, 50, 0);
+
+        // when
+        int lateMinutes = AttendanceSettlementCalculator.calculateLateMinutes(scheduled, checkIn);
+
+        // then
+        assertThat(lateMinutes).isZero();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceSettlementCalculatorTest.java
@@ -2,6 +2,7 @@ package com.yanus.attendance.attendance.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementCalculator;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceTest.java
@@ -3,6 +3,8 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;

--- a/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
@@ -29,7 +29,7 @@ public class WorkScheduleTest {
         LocalTime end = LocalTime.of(18, 0);
 
         // when
-        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end, null);
 
         // then
         assertThat(schedule.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
@@ -45,7 +45,7 @@ public class WorkScheduleTest {
 
         // when & then
         assertThatThrownBy(() ->
-                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0)))
+                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0), null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("종료 시간");
     }
@@ -55,7 +55,7 @@ public class WorkScheduleTest {
     void update_work_schedule() {
         // given
         WorkSchedule schedule = WorkSchedule.create(createMember(), DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0));
+                LocalTime.of(9, 0), LocalTime.of(18, 0), null);
 
         // when
         schedule.update(LocalTime.of(10, 0), LocalTime.of(19, 0));

--- a/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;

--- a/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
+++ b/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.auth;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class FakeEmailVerificationTokenRepository {
+
+    private final Map<Lomg, EmailVerificationToken> store = new HashMap<>();
+    private long sequence = 1;
+
+    @Override
+    public EmailVerificationToken save(EmailVerificationToken token) {
+        store.put(sequence++, token);
+        return token;
+    }
+
+    @Override
+    public Optional<EmailVerificationToken> findByToken(String token) {
+        return store.values().stream()
+                .filter(t -> t.getToken().equals(token))
+                .findFirst();
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        store.values().removeIf(t -> t.getMemberId().equals(memberId));
+    }
+
+    public List<EmailVerificationToken> findAll() {
+        return new ArrayList<>(store.values());
+    }
+}

--- a/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
+++ b/src/test/java/com/yanus/attendance/auth/FakeEmailVerificationTokenRepository.java
@@ -1,11 +1,16 @@
 package com.yanus.attendance.auth;
 
+import com.yanus.attendance.auth.domain.EmailVerificationToken;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-public class FakeEmailVerificationTokenRepository {
+public class FakeEmailVerificationTokenRepository implements EmailVerificationTokenRepository {
 
-    private final Map<Lomg, EmailVerificationToken> store = new HashMap<>();
+    private final Map<Long, EmailVerificationToken> store = new HashMap<>();
     private long sequence = 1;
 
     @Override

--- a/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
@@ -2,7 +2,11 @@ package com.yanus.attendance.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 
+import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
 import com.yanus.attendance.auth.FakeRefreshTokenRepository;
 import com.yanus.attendance.auth.infrastructure.JwtTokenProvider;
 import com.yanus.attendance.auth.presentation.dto.LoginRequest;
@@ -13,6 +17,7 @@ import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +43,12 @@ class AuthServiceTest {
                 3600000L,
                 604800000L
         );
+
+        EmailService emailService = mock(EmailService.class);
+        doNothing().when(emailService).sendVerificationEmail(anyString(), anyString());
+        EmailVerificationService emailVerificationService = new EmailVerificationService(
+                new FakeEmailVerificationTokenRepository(), memberRepository, emailService);
+
         authService = new AuthService(
                 memberRepository,
                 refreshTokenRepository,
@@ -89,6 +100,7 @@ class AuthServiceTest {
 
         // when
         LoginResponse response = authService.login(request);
+        memberRepository.findByEmail("hong@yanus.com").get().activate();
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -276,5 +288,32 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "wrongpassword")))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_LOCKED);
+    }
+
+    @Test
+    @DisplayName("회원가입 후 PENDING 상태로 저장")
+    void register_saves_member_as_pending_status() {
+        // given
+        Team team = savedTeam();
+
+        // when
+        authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+
+        // then
+        assertThat(memberRepository.findByEmail("hong@yanus.com").get().getStatus())
+                .isEqualTo(MemberStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태 멤버 로그인 시 예외 발생")
+    void PENDING_member_login_throw_error() {
+        // given
+        Team team = savedTeam();
+        authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "password123")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_PENDING);
     }
 }

--- a/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/AuthServiceTest.java
@@ -54,12 +54,17 @@ class AuthServiceTest {
                 refreshTokenRepository,
                 teamRepository,
                 jwtTokenProvider,
-                new BCryptPasswordEncoder()
+                new BCryptPasswordEncoder(),
+                emailVerificationService
         );
     }
 
     private Team savedTeam() {
         return teamRepository.save(Team.create("1팀"));
+    }
+
+    private void activate(String email) {
+        memberRepository.findByEmail(email).get().activate();
     }
 
     @Test
@@ -96,11 +101,11 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginRequest request = new LoginRequest("hong@yanus.com", "password123");
 
         // when
         LoginResponse response = authService.login(request);
-        memberRepository.findByEmail("hong@yanus.com").get().activate();
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -140,6 +145,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         RefreshRequest request = new RefreshRequest(loginResponse.refreshToken());
 
@@ -170,6 +176,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
 
         // when
@@ -186,6 +193,7 @@ class AuthServiceTest {
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
         Member member = memberRepository.findByEmail("hong@yanus.com").get();
+        member.activate();
         member.deactivate();
         LoginRequest request = new LoginRequest("hong@yanus.com", "password123");
 
@@ -201,6 +209,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("김인직", "asdasd@naver.com", "asdasd12", team.getId()));
+        activate("asdasd@naver.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("asdasd@naver.com", "asdasd12"));
         String oldRefreshToken = loginResponse.refreshToken();
 
@@ -218,9 +227,10 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         String oldRefreshToken = loginResponse.refreshToken();
-        authService.refresh(new RefreshRequest(oldRefreshToken)); // 1회 사용
+        authService.refresh(new RefreshRequest(oldRefreshToken));
 
         // when & then
         assertThatThrownBy(() -> authService.refresh(new RefreshRequest(oldRefreshToken)))
@@ -234,6 +244,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         LoginResponse loginResponse = authService.login(new LoginRequest("hong@yanus.com", "password123"));
         String oldRefreshToken = loginResponse.refreshToken();
         LoginResponse rotated = authService.refresh(new RefreshRequest(oldRefreshToken));
@@ -272,6 +283,7 @@ class AuthServiceTest {
         // given
         Team team = savedTeam();
         authService.register(new RegisterRequest("홍길동", "hong@yanus.com", "password123", team.getId()));
+        activate("hong@yanus.com");
         for (int i = 0; i < 4; i++) {
             assertThatThrownBy(() -> authService.login(new LoginRequest("hong@yanus.com", "wrongpassword")))
                     .isInstanceOf(BusinessException.class);

--- a/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
@@ -1,0 +1,101 @@
+package com.yanus.attendance.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
+import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailVerificationServiceTest {
+
+    private EmailVerificationService emailVerificationService;
+    private FakeMemberRepository memberRepository;
+    private FakeEmailVerificationTokenRepository tokenRepository;
+
+    @BeforeEach
+    public void setUp() {
+        memberRepository = new FakeMemberRepository();
+        tokenRepository = new FakeEmailVerificationTokenRepository();
+        EmailService emailService = mock(EmailService.class);
+        doNothing().when(emailService).sendVerification(anyString(), anyString());
+        emailVerificationService = new EmailVerificationService(tokenRepository, memberRepository, emailService);
+    }
+
+    private Member createMember() {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create("홍길동", "hong@yanus.com", "password123",
+                MemberRole.MEMBER, MemberStatus.PENDING, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("인증 토큰으로 인증 시 ACTIVE로 변경")
+    void token_verification_active() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String token = tokenRepository.findAll().get(0).getToken();
+
+        // when
+        emailVerificationService.verify(token);
+
+        // then
+        assertThat(memberRepository.findById(member.getId().get().getStatus()))
+                .isEqualTo(MemberStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토큰으로 인증 시 예외 발생")
+    void invalid_token_try_verify_is_error() {
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verify("invalid-tokenn"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCodee", ErrorCode.INVALID_VERIFICATION_TOKEN);
+    }
+
+    @Test
+    @DisplayName("재발송 시 기존 토큰 삭제 후 새 토큰 발급")
+    void if_retry_old_token_remove_new_token_serve() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String firstToken = tokenRepository.findAll().get(0).getToken();
+
+        // when
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String secondToken = tokenRepository.findAll().get(0).getToken();
+
+        // then
+        assertThat(firstToken).isNotEqualTo(secondToken);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 토큰으로 인증 시 예외 발생")
+    void used_token_try_verify_is_error() {
+        // given
+        Member member = createMember();
+        emailVerificationService.sendVerification(member.getId(), member.getEmail());
+        String token = tokenRepository.findAll().get(0).getToken();
+        emailVerificationService.verify(token);
+
+        // when & then
+        assertThatThrownBy(() -> emailVerificationService.verify(token))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_VERIFICATION_TOKEN);
+    }
+}

--- a/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
+++ b/src/test/java/com/yanus/attendance/auth/application/EmailVerificationServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 import com.yanus.attendance.auth.FakeEmailVerificationTokenRepository;
-import com.yanus.attendance.auth.domain.EmailVerificationTokenRepository;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.FakeMemberRepository;
@@ -28,10 +27,10 @@ public class EmailVerificationServiceTest {
 
     @BeforeEach
     public void setUp() {
-        memberRepository = new FakeMemberRepository();
         tokenRepository = new FakeEmailVerificationTokenRepository();
+        memberRepository = new FakeMemberRepository();
         EmailService emailService = mock(EmailService.class);
-        doNothing().when(emailService).sendVerification(anyString(), anyString());
+        doNothing().when(emailService).sendVerificationEmail(anyString(), anyString());
         emailVerificationService = new EmailVerificationService(tokenRepository, memberRepository, emailService);
     }
 
@@ -55,7 +54,7 @@ public class EmailVerificationServiceTest {
         emailVerificationService.verify(token);
 
         // then
-        assertThat(memberRepository.findById(member.getId().get().getStatus()))
+        assertThat(memberRepository.findById(member.getId()).get().getStatus())
                 .isEqualTo(MemberStatus.ACTIVE);
     }
 
@@ -65,7 +64,7 @@ public class EmailVerificationServiceTest {
         // when & then
         assertThatThrownBy(() -> emailVerificationService.verify("invalid-tokenn"))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCodee", ErrorCode.INVALID_VERIFICATION_TOKEN);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_VERIFICATION_TOKEN);
     }
 
     @Test

--- a/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
@@ -16,6 +16,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.member.presentation.dto.MemberResponse;
 import com.yanus.attendance.member.presentation.dto.ProfileUpdateRequest;
 import com.yanus.attendance.member.presentation.dto.RoleChangeRequest;
+import com.yanus.attendance.member.presentation.dto.TemporaryPasswordResponse;
 import com.yanus.attendance.team.FakeTeamRepository;
 import com.yanus.attendance.team.domain.Team;
 import org.junit.jupiter.api.BeforeEach;
@@ -396,13 +397,13 @@ public class MemberServiceTest {
         Member target = createMember("target@yanus.com", MemberRole.MEMBER);
 
         // when
-        TeamPoraryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
+        TemporaryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
 
         // then
         assertThat(response.temporaryPassword()).hasSize(8);
     }
 
-    Test
+    @Test
     @DisplayName("임시 비밀번호 발급 후 변경된 비밀번호로 인코딩 저장")
     void 임시_비밀번호_발급_후_인코딩_저장() {
         // given

--- a/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
+++ b/src/test/java/com/yanus/attendance/member/application/MemberServiceTest.java
@@ -387,4 +387,75 @@ public class MemberServiceTest {
         assertThat(auditLogRepository.findAll()).hasSize(1);
         assertThat(auditLogRepository.findAll().get(0).getAction()).isEqualTo(AuditAction.TEAM_CHANGE);
     }
+
+    @Test
+    @DisplayName("관리자가 임시 비밀번호 발급")
+    void 관리자가_임시_비밀번호_발급() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when
+        TeamPoraryPasswordResponse response = memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(response.temporaryPassword()).hasSize(8);
+    }
+
+    Test
+    @DisplayName("임시 비밀번호 발급 후 변경된 비밀번호로 인코딩 저장")
+    void 임시_비밀번호_발급_후_인코딩_저장() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+        String originalPassword = target.getPassword();
+
+        // when
+        memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(memberRepository.findById(target.getId()).get().getPassword())
+                .isNotEqualTo(originalPassword);
+    }
+
+    @Test
+    @DisplayName("ADMIN이 아니면 임시 비밀번호 발급 시 FORBIDDEN")
+    void ADMIN이_아니면_임시_비밀번호_발급_시_FORBIDDEN() {
+        // given
+        Member actor = createMember("actor@yanus.com", MemberRole.MEMBER);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.resetPassword(actor.getId(), target.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버 임시 비밀번호 발급 시 MEMBER_NOT_FOUND")
+    void 존재하지_않는_멤버_임시_비밀번호_발급_시_MEMBER_NOT_FOUND() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.resetPassword(admin.getId(), 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("임시 비밀번호 발급 시 감사 로그 저장")
+    void 임시_비밀번호_발급_시_감사_로그_저장() {
+        // given
+        Member admin = createMember("admin@yanus.com", MemberRole.ADMIN);
+        Member target = createMember("target@yanus.com", MemberRole.MEMBER);
+
+        // when
+        memberService.resetPassword(admin.getId(), target.getId());
+
+        // then
+        assertThat(auditLogRepository.findAll()).hasSize(1);
+        assertThat(auditLogRepository.findAll().get(0).getAction())
+                .isEqualTo(AuditAction.PASSWORD_RESET);
+    }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -19,3 +19,13 @@ minio.access-key=test
 minio.secret-key=testpassword
 minio.bucket=test-bucket
 
+# =====================
+# Mail (테스트용 더미)
+# =====================
+spring.mail.host=localhost
+spring.mail.port=25
+spring.mail.username=test
+spring.mail.password=test
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+


### PR DESCRIPTION
## 관련 이슈
closes #139

## 작업 내용
- 회원가입 시 이메일 인증 메일 발송 및 MemberStatus PENDING 처리
- 이메일 인증 완료 시 ACTIVE로 상태 변경 (`POST /api/v1/auth/verify-email`)
- 인증 메일 재발송 기능 추가 (`POST /api/v1/auth/verify-email/resend`)
- PENDING 상태 멤버 로그인 차단
- EmailVerificationToken 도메인 및 V18 마이그레이션 추가
- spring-boot-starter-mail 의존성 추가 및 Gmail SMTP 설정
- 테스트용 Mail 더미 설정 추가

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
