### PR TITLE
[Fix] #149 - WorkScheduleEvent createdAt 필드 추가

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEvent.java
@@ -13,11 +13,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "work_schedule_event")
@@ -39,6 +40,10 @@ public class WorkScheduleEvent {
     private LocalTime startTime;
 
     private LocalTime endTime;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     public static WorkScheduleEvent create(Member member, LocalDate date, LocalTime startTime, LocalTime endTime) {
         validateTime(startTime, endTime);


### PR DESCRIPTION
## 관련 이슈
closes #149

## 작업 내용
- WorkScheduleEvent 엔티티에 createdAt 필드 누락으로 날짜별 근무 일정 등록 시 DB NOT NULL 제약 위반 발생
- @CreationTimestamp 추가로 INSERT 시 자동 설정되도록 수정

## 체크리스트
- [x] 버그 원인 확인
- [x] 수정 완료
- [x] 테스트 전체 통과
