### PR TITLE
[Fix] #156 - 자동 체크아웃 실행 시점 버그 수정

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.attendance.application.attendance;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,9 +12,8 @@ public class AttendanceScheduler {
 
     private final AttendanceService attendanceService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 * * * * *")
     public void autoCheckOut() {
-        LocalDate yesterday =LocalDate.now().minusDays(1);
-        attendanceService.autoCheckOut(yesterday);
+        attendanceService.autoCheckOut(LocalDate.now(), LocalTime.now());
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
@@ -66,11 +66,14 @@ public class AttendanceService {
                 .toList();
     }
 
-    public void autoCheckOut(LocalDate workDate) {
+    public void autoCheckOut(LocalDate workDate, LocalTime currentTime) {
+        LocalTime configuredTime = attendanceSettingService.getAutoCheckoutTimeValue();
+        if (currentTime.isBefore(configuredTime)) {
+            return;
+        }
         List<Attendance> workingAttendances =
                 attendanceRepository.findAllByWorkDateAndStatus(workDate, AttendanceStatus.WORKING);
-        LocalTime checkoutTime = attendanceSettingService.getAutoCheckoutTimeValue();
-        LocalDateTime checkOutTime = workDate.atTime(checkoutTime);
+        LocalDateTime checkOutTime = workDate.atTime(configuredTime);
         workingAttendances.forEach(attendance -> attendance.checkOut(checkOutTime));
     }
 

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -25,6 +25,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,7 +187,7 @@ public class AttendanceServiceTest {
         attendanceService.checkIn(member.getId());
 
         // when
-        attendanceService.autoCheckOut(date);
+        attendanceService.autoCheckOut(date, LocalTime.of(23, 59, 59));
         List<AttendanceResponse> responses = attendanceService.getMyAttendances(member.getId());
 
         // then


### PR DESCRIPTION
## 관련 이슈
closes #156 

## 작업 내용
- `AttendanceScheduler` 실행 주기 자정 1회 → 매분 실행으로 변경
- 자동 체크아웃 대상을 `어제` → `오늘` 기록으로 수정
- 현재 시각이 설정된 `autoCheckoutTime` 이상일 때만 처리하도록 조건 추가
- `autoCheckOut()` 시그니처에 `LocalTime currentTime` 파라미터 추가 (테스트 시각 주입 가능)
- 기존 `WORKING` 상태 필터링으로 중복 처리 자연스럽게 방지
- 서비스 테스트 수정 및 추가 (설정 시간 전/후, 기본값, 중복 실행)

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과