### PR TITLE
[v3.8] #156 - 자동 체크아웃 실행 시점 버그 수정

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.attendance.application.attendance;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,9 +12,8 @@ public class AttendanceScheduler {
 
     private final AttendanceService attendanceService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 * * * * *")
     public void autoCheckOut() {
-        LocalDate yesterday =LocalDate.now().minusDays(1);
-        attendanceService.autoCheckOut(yesterday);
+        attendanceService.autoCheckOut(LocalDate.now(), LocalTime.now());
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
@@ -66,11 +66,14 @@ public class AttendanceService {
                 .toList();
     }
 
-    public void autoCheckOut(LocalDate workDate) {
+    public void autoCheckOut(LocalDate workDate, LocalTime currentTime) {
+        LocalTime configuredTime = attendanceSettingService.getAutoCheckoutTimeValue();
+        if (currentTime.isBefore(configuredTime)) {
+            return;
+        }
         List<Attendance> workingAttendances =
                 attendanceRepository.findAllByWorkDateAndStatus(workDate, AttendanceStatus.WORKING);
-        LocalTime checkoutTime = attendanceSettingService.getAutoCheckoutTimeValue();
-        LocalDateTime checkOutTime = workDate.atTime(checkoutTime);
+        LocalDateTime checkOutTime = workDate.atTime(configuredTime);
         workingAttendances.forEach(attendance -> attendance.checkOut(checkOutTime));
     }
 

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -25,6 +25,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -186,7 +187,7 @@ public class AttendanceServiceTest {
         attendanceService.checkIn(member.getId());
 
         // when
-        attendanceService.autoCheckOut(date);
+        attendanceService.autoCheckOut(date, LocalTime.of(23, 59, 59));
         List<AttendanceResponse> responses = attendanceService.getMyAttendances(member.getId());
 
         // then


### PR DESCRIPTION
## 관련 이슈
closes #156

## 작업 내용
- 자동 체크아웃이 자정에 전날 기록을 일괄 후처리하던 구조를 실시간 처리로 변경
- 스케줄러 주기를 매분으로 변경하여 설정 시간 도달 시점에 자동 퇴근 처리
- 대상을 오늘 날짜의 `WORKING` 기록으로 수정, `LEFT` 상태는 자연스럽게 제외되어 중복 처리 방지
- 테스트에 시각 주입이 가능하도록 파라미터 구조 개선

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과