### PR TITLE
[ATT] #159 - 출퇴근 예외 도메인 + 조회 API 추가

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,35 @@
+1. 인덱스 (가장 급함)
+   지금 마이그레이션에 인덱스가 거의 없어. 조회 쿼리에서 무조건 풀스캔 중.
+
+자주 쓰이는 것들
+```sql
+CREATE INDEX idx_attendance_member_date ON attendance (member_id, work_date);
+CREATE INDEX idx_attendance_work_date ON attendance (work_date);
+CREATE INDEX idx_work_schedule_member ON work_schedule (member_id);
+CREATE INDEX idx_leave_request_member ON leave_request (member_id);
+CREATE INDEX idx_task_date ON task (date);
+CREATE INDEX idx_refresh_token_member ON refresh_token (member_id);
+```
+
+2. N+1 문제
+   findAll() 같은 목록 조회에서 member → team 이런 연관관계 로딩할 때 N+1 발생 가능성 높음. fetch join 또는 @EntityGraph 적용 필요.
+
+3. 페이지네이션
+   지금 GET /api/v1/attendances, GET /api/v1/members 같은 목록 API가 전체를 다 끌고 옴. 데이터 쌓이면 터짐. Pageable 적용 필요.
+
+4. AttendanceSettlementService 계산 로직
+   월별 지각 정산이 Java 레벨에서 루프 돌면서 계산하는 구조인데, 데이터 많아지면 느려짐. 핵심 집계는 DB 쿼리로 내리는 게 나음.
+
+5. Redis 캐싱
+   attendance_setting 테이블 — 자동 체크아웃 시간은 거의 안 바뀌는데 스케줄러 돌 때마다 조회함. Redis에 캐싱하면 DB 불필요한 hit 줄어듦
+   refresh_token 조회 — 모든 인증 요청마다 DB hit, Redis로 대체 가능
+
+6. 자동 체크아웃 스케줄러
+   지금 매일 자정에 미퇴근자 전체 조회해서 처리하는 구조인데, 데이터 많아지면 한 번에 너무 많은 row를 업데이트함. Batch size 나눠서 처리하는 청크 방식이 안전함.
+
+우선순위로 따지면:
+
+인덱스 → 바로 효과 있고 리스크 없음
+N+1 → 목록 API 많아서 체감 큼
+페이지네이션 → API 스펙 변경 필요해서 프론트 협의 필요
+나머지는 트래픽이 진짜 생겼을 때

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -6,6 +6,7 @@ import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.exception.*;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionSummary;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
 import java.time.LocalDate;
@@ -34,6 +35,25 @@ public class AttendanceExceptionService {
             String teamName) {
         generateMissingExceptions(date);
         return filterExceptions(exceptionRepository.findAllByWorkDate(date), type, status, teamName);
+    }
+
+    @Transactional(readOnly = true)
+    public AttendanceExceptionSummary getSummary(LocalDate date) {
+        List<AttendanceException> all = exceptionRepository.findAllByWorkDate(date);
+        return buildSummary(all, all);
+    }
+
+    private AttendanceExceptionSummary buildSummary(
+            List<AttendanceException> all, List<AttendanceException> filtered) {
+        return new AttendanceExceptionSummary(
+                all.size(),
+                filtered.size(),
+                countByStatus(all, AttendanceExceptionStatus.OPEN),
+                countByType(all, AttendanceExceptionType.MISSED_CHECK_IN),
+                countByType(all, AttendanceExceptionType.MISSED_CHECK_OUT),
+                countByType(all, AttendanceExceptionType.LATE),
+                countByType(all, AttendanceExceptionType.NO_SCHEDULE)
+        );
     }
 
     private void generateMissingExceptions(LocalDate date) {
@@ -118,5 +138,17 @@ public class AttendanceExceptionService {
             return true;
         }
         return teamName.equals(e.getMember().getTeam().getName());
+    }
+
+    private int countByType(List<AttendanceException> exceptions, AttendanceExceptionType type) {
+        return (int) exceptions.stream()
+                .filter(e -> e.getType() == type)
+                .count();
+    }
+
+    private int countByStatus(List<AttendanceException> exceptions, AttendanceExceptionStatus status) {
+        return (int) exceptions.stream()
+                .filter(e -> e.getStatus() == status)
+                .count();
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -1,0 +1,122 @@
+package com.yanus.attendance.attendance.application.exception;
+
+import com.yanus.attendance.attendance.application.setting.AttendanceSettingService;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.exception.*;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceExceptionService {
+
+    private final AttendanceExceptionRepository exceptionRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final WorkScheduleRepository workScheduleRepository;
+    private final MemberRepository memberRepository;
+    private final AttendanceSettingService settingService;
+    private final AttendanceExceptionJudge judge = new AttendanceExceptionJudge();
+
+    @Transactional
+    public List<AttendanceException> getExceptions(
+            LocalDate date,
+            AttendanceExceptionType type,
+            AttendanceExceptionStatus status,
+            String teamName) {
+        generateMissingExceptions(date);
+        return filterExceptions(exceptionRepository.findAllByWorkDate(date), type, status, teamName);
+    }
+
+    private void generateMissingExceptions(LocalDate date) {
+        boolean thresholdPassed = isThresholdPassed(date);
+        memberRepository.findAll()
+                .forEach(member -> generateFor(member, date, thresholdPassed));
+    }
+
+    private void generateFor(Member member, LocalDate date, boolean thresholdPassed) {
+        WorkSchedule schedule = findSchedule(member, date);
+        Attendance attendance = findAttendance(member, date);
+        List<AttendanceExceptionType> detected = judge.judge(schedule, attendance, thresholdPassed);
+        detected.forEach(type -> saveIfAbsent(member, attendance, date, type));
+    }
+
+    private WorkSchedule findSchedule(Member member, LocalDate date) {
+        return workScheduleRepository
+                .findByMemberIdAndDayOfWeek(member.getId(), date.getDayOfWeek())
+                .orElse(null);
+    }
+
+    private Attendance findAttendance(Member member, LocalDate date) {
+        return attendanceRepository
+                .findByMemberIdAndWorkDate(member.getId(), date)
+                .orElse(null);
+    }
+
+    private void saveIfAbsent(Member member, Attendance attendance,
+                              LocalDate date, AttendanceExceptionType type) {
+        if (alreadyExists(member, date, type)) {
+            return;
+        }
+        exceptionRepository.save(AttendanceException.open(member, attendance, date, type));
+    }
+
+    private boolean alreadyExists(Member member, LocalDate date, AttendanceExceptionType type) {
+        return exceptionRepository
+                .findByMemberIdAndWorkDateAndType(member.getId(), date, type)
+                .isPresent();
+    }
+
+    private boolean isThresholdPassed(LocalDate date) {
+        LocalDate today = LocalDate.now();
+        if (date.isBefore(today)) {
+            return true;
+        }
+        if (date.isAfter(today)) {
+            return false;
+        }
+        LocalTime threshold = settingService.getAutoCheckoutTimeValue();
+        return !LocalTime.now().isBefore(threshold);
+    }
+
+    private List<AttendanceException> filterExceptions(
+            List<AttendanceException> all,
+            AttendanceExceptionType type,
+            AttendanceExceptionStatus status,
+            String teamName) {
+        return all.stream()
+                .filter(e -> matchesType(e, type))
+                .filter(e -> matchesStatus(e, status))
+                .filter(e -> matchesTeam(e, teamName))
+                .toList();
+    }
+
+    private boolean matchesType(AttendanceException e, AttendanceExceptionType type) {
+        if (type == null) {
+            return true;
+        }
+        return e.getType() == type;
+    }
+
+    private boolean matchesStatus(AttendanceException e, AttendanceExceptionStatus status) {
+        if (status == null) {
+            return true;
+        }
+        return e.getStatus() == status;
+    }
+
+    private boolean matchesTeam(AttendanceException e, String teamName) {
+        if (teamName == null) {
+            return true;
+        }
+        return teamName.equals(e.getMember().getTeam().getName());
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -6,6 +6,8 @@ import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.exception.*;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionListResponse;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionSummary;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
@@ -41,6 +43,41 @@ public class AttendanceExceptionService {
     public AttendanceExceptionSummary getSummary(LocalDate date) {
         List<AttendanceException> all = exceptionRepository.findAllByWorkDate(date);
         return buildSummary(all, all);
+    }
+
+    @Transactional
+    public AttendanceExceptionListResponse getList(
+            LocalDate date,
+            AttendanceExceptionType type,
+            AttendanceExceptionStatus status,
+            String teamName) {
+        generateMissingExceptions(date);
+        List<AttendanceException> all = exceptionRepository.findAllByWorkDate(date);
+        List<AttendanceException> filtered = filterExceptions(all, type, status, teamName);
+        AttendanceExceptionSummary summary = buildSummary(all, filtered);
+        List<AttendanceExceptionResponse> items = filtered.stream()
+                .map(this::toResponse)
+                .toList();
+        return new AttendanceExceptionListResponse(date, summary, items);
+    }
+
+    private AttendanceExceptionResponse toResponse(AttendanceException exception) {
+        WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
+        return AttendanceExceptionResponse.from(exception, startOf(schedule), endOf(schedule));
+    }
+
+    private LocalTime startOf(WorkSchedule schedule) {
+        if (schedule == null) {
+            return null;
+        }
+        return schedule.getStartTime();
+    }
+
+    private LocalTime endOf(WorkSchedule schedule) {
+        if (schedule == null) {
+            return null;
+        }
+        return schedule.getEndTime();
     }
 
     private AttendanceExceptionSummary buildSummary(

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceException.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceException.java
@@ -1,0 +1,73 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "attendance_exception")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AttendanceException {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attendance_id")
+    private Attendance attendance;
+
+    @Column(nullable = false)
+    private LocalDate workDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttendanceExceptionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AttendanceExceptionStatus status;
+
+    private String note;
+    private String reason;
+    private String approvedBy;
+    private LocalDateTime approvedAt;
+    private String resolvedBy;
+    private LocalDateTime resolvedAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static AttendanceException open(
+            Member member, Attendance attendance, LocalDate workDate, AttendanceExceptionType type
+    ) {
+        AttendanceException exception = new AttendanceException();
+        exception.member = member;
+        exception.attendance = attendance;
+        exception.workDate = workDate;
+        exception.type = type;
+        exception.status = AttendanceExceptionStatus.OPEN;
+        exception.createdAt = LocalDateTime.now();
+        return exception;
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
@@ -1,0 +1,16 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendanceExceptionJpaRepository extends JpaRepository<AttendanceException, Long>, AttendanceExceptionRepository {
+
+    @Override
+    Optional<AttendanceException> findByMemberIdAndWorkDateAndType(
+            Long memberId, LocalDate workDate, AttendanceExceptionType type);
+
+    @Override
+    List<AttendanceException> findAllByWorkDate(LocalDate workDate);
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -29,6 +29,10 @@ public class AttendanceExceptionJudge {
             result.add(AttendanceExceptionType.LATE);
         }
 
+        if (isMissedCheckout(hasSchedule, hasAttendance, missedCheckoutThresholdPassed)) {
+            result.add(AttendanceExceptionType.MISSED_CHECK_OUT);
+        }
+
         return result;
     }
 
@@ -43,5 +47,9 @@ public class AttendanceExceptionJudge {
     private boolean isLate(boolean hasSchedule, boolean hasAttendance, Attendance attendance, WorkSchedule schedule) {
         return hasSchedule && hasAttendance
                 && attendance.getCheckInTime().toLocalTime().isAfter(schedule.getStartTime());
+    }
+
+    private boolean isMissedCheckout(boolean hasSchedule, boolean hasAttendance, boolean missedCheckoutThresholdPassed) {
+        return hasSchedule && hasAttendance && missedCheckoutThresholdPassed;
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -1,0 +1,25 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AttendanceExceptionJudge {
+
+    public List<AttendanceExceptionType> judge(
+            WorkSchedule schedule,
+            Attendance attendance,
+            boolean missedCheckoutThresholdPassed
+    ) {
+        List<AttendanceExceptionType> result = new ArrayList<>();
+
+        boolean hasSchedule = schedule != null;
+        boolean hasAttendance = attendance != null;
+
+        if (hasSchedule && !hasAttendance) {
+            result.add(AttendanceExceptionType.MISSED_CHECK_IN);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -20,6 +20,11 @@ public class AttendanceExceptionJudge {
         if (hasSchedule && !hasAttendance) {
             result.add(AttendanceExceptionType.MISSED_CHECK_IN);
         }
+
+        if (!hasSchedule && hasAttendance) {
+            result.add(AttendanceExceptionType.NO_SCHEDULE);
+        }
+
         return result;
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -17,14 +17,31 @@ public class AttendanceExceptionJudge {
         boolean hasSchedule = schedule != null;
         boolean hasAttendance = attendance != null;
 
-        if (hasSchedule && !hasAttendance) {
+        if (isMissedCheckIn(hasSchedule, hasAttendance)) {
             result.add(AttendanceExceptionType.MISSED_CHECK_IN);
         }
 
-        if (!hasSchedule && hasAttendance) {
+        if (isNoSchedule(hasSchedule, hasAttendance)) {
             result.add(AttendanceExceptionType.NO_SCHEDULE);
         }
 
+        if (isLate(hasSchedule, hasAttendance, attendance, schedule)) {
+            result.add(AttendanceExceptionType.LATE);
+        }
+
         return result;
+    }
+
+    private boolean isMissedCheckIn(boolean hasSchedule, boolean hasAttendance) {
+        return hasSchedule && !hasAttendance;
+    }
+
+    private boolean isNoSchedule(boolean hasSchedule, boolean hasAttendance) {
+        return !hasSchedule && hasAttendance;
+    }
+
+    private boolean isLate(boolean hasSchedule, boolean hasAttendance, Attendance attendance, WorkSchedule schedule) {
+        return hasSchedule && hasAttendance
+                && attendance.getCheckInTime().toLocalTime().isAfter(schedule.getStartTime());
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
@@ -1,0 +1,14 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface AttendanceExceptionRepository {
+    AttendanceException save(AttendanceException attendanceException);
+    Optional<AttendanceException> findById(Long id);
+    Optional<AttendanceException> findByMemberIdAndWorkDateAndType(
+            Long memberId, LocalDate workDate, AttendanceExceptionType type
+    );
+    List<AttendanceException> findAllByWorkDate(LocalDate workDate);
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionStatus.java
@@ -1,0 +1,8 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+public enum AttendanceExceptionStatus {
+    OPEN,
+    APPROVED,
+    REJECTED,
+    RESOLVED
+}

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionType.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionType.java
@@ -1,0 +1,8 @@
+package com.yanus.attendance.attendance.domain.exception;
+
+public enum AttendanceExceptionType {
+    MISSED_CHECK_IN,
+    MISSED_CHECK_OUT,
+    LATE,
+    NO_SCHEDULE
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionListResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionListResponse.java
@@ -1,0 +1,9 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AttendanceExceptionListResponse(
+        LocalDate date, AttendanceExceptionSummary summary, List<AttendanceExceptionResponse> items
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionResponse.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation.dto;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.exception.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +29,7 @@ public record AttendanceExceptionResponse(
     public static AttendanceExceptionResponse from(
             AttendanceException e,
             LocalTime scheduledStart, LocalTime scheduledEnd) {
+        Attendance attendance = e.getAttendance();
         return new AttendanceExceptionResponse(
                 e.getId(),
                 e.getMember().getId(),
@@ -42,11 +44,32 @@ public record AttendanceExceptionResponse(
                 e.getApprovedAt(),
                 e.getResolvedBy(),
                 e.getResolvedAt(),
-                e.getAttendance() != null ? e.getAttendance().getId() : null,
+                attendanceId(attendance),
                 scheduledStart,
                 scheduledEnd,
-                e.getAttendance() != null ? e.getAttendance().getCheckInTime() : null,
-                e.getAttendance() != null ? e.getAttendance().getCheckOutTime() : null
+                checkIn(attendance),
+                checkOut(attendance)
         );
+    }
+
+    private static Long attendanceId(Attendance attendance) {
+        if (attendance == null) {
+            return null;
+        }
+        return attendance.getId();
+    }
+
+    private static LocalDateTime checkIn(Attendance attendance) {
+        if (attendance == null) {
+            return null;
+        }
+        return attendance.getCheckInTime();
+    }
+
+    private static LocalDateTime checkOut(Attendance attendance) {
+        if (attendance == null) {
+            return null;
+        }
+        return attendance.getCheckOutTime();
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionResponse.java
@@ -1,0 +1,52 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+import com.yanus.attendance.attendance.domain.exception.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record AttendanceExceptionResponse(
+        Long id,
+        Long memberId,
+        String memberName,
+        String teamName,
+        LocalDate workDate,
+        AttendanceExceptionType type,
+        AttendanceExceptionStatus status,
+        String note,
+        String reason,
+        String approvedBy,
+        LocalDateTime approvedAt,
+        String resolvedBy,
+        LocalDateTime resolvedAt,
+        Long attendanceRecordId,
+        LocalTime scheduledStartTime,
+        LocalTime scheduledEndTime,
+        LocalDateTime checkInTime,
+        LocalDateTime checkOutTime
+) {
+    public static AttendanceExceptionResponse from(
+            AttendanceException e,
+            LocalTime scheduledStart, LocalTime scheduledEnd) {
+        return new AttendanceExceptionResponse(
+                e.getId(),
+                e.getMember().getId(),
+                e.getMember().getName(),
+                e.getMember().getTeam().getName(),
+                e.getWorkDate(),
+                e.getType(),
+                e.getStatus(),
+                e.getNote(),
+                e.getReason(),
+                e.getApprovedBy(),
+                e.getApprovedAt(),
+                e.getResolvedBy(),
+                e.getResolvedAt(),
+                e.getAttendance() != null ? e.getAttendance().getId() : null,
+                scheduledStart,
+                scheduledEnd,
+                e.getAttendance() != null ? e.getAttendance().getCheckInTime() : null,
+                e.getAttendance() != null ? e.getAttendance().getCheckOutTime() : null
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionSummary.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/AttendanceExceptionSummary.java
@@ -1,0 +1,12 @@
+package com.yanus.attendance.attendance.presentation.dto;
+
+public record AttendanceExceptionSummary(
+        int totalCount,
+        int filteredCount,
+        int openCount,
+        int missedCheckInCount,
+        int missedCheckOutCount,
+        int lateCount,
+        int noScheduleCount
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/exception/AttendanceExceptionController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/exception/AttendanceExceptionController.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.attendance.presentation.exception;
+
+import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionStatus;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionListResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "출/퇴근 예외목록 반환", description = "지각, 미출근, 미퇴근, 근무 일정 미기입 확인")
+@RestController
+@RequestMapping("/api/v1/attendance-exceptions")
+@RequiredArgsConstructor
+public class AttendanceExceptionController {
+
+    private final AttendanceExceptionService attendanceExceptionService;
+
+    @GetMapping
+    public AttendanceExceptionListResponse getExceptions(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) AttendanceExceptionType type,
+            @RequestParam(required = false) AttendanceExceptionStatus status,
+            @RequestParam(required = false) String teamName) {
+        return attendanceExceptionService.getList(date, type, status, teamName);
+    }
+}

--- a/src/main/java/com/yanus/attendance/member/domain/MemberRepository.java
+++ b/src/main/java/com/yanus/attendance/member/domain/MemberRepository.java
@@ -4,14 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository {
-
     Member save(Member member);
-
     Optional<Member> findById(Long id);
-
     Optional<Member> findByEmail(String email);
-
     boolean existsByEmail(String email);
-
     List<Member> findAllByIds(List<Long> ids);
+    List<Member> findAll();
+    List<Member> findAllByTeamName(String teamName);
 }

--- a/src/main/java/com/yanus/attendance/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/member/infrastructure/MemberJpaRepository.java
@@ -38,13 +38,21 @@ public class MemberJpaRepository implements MemberRepository {
         return port.findAllByIdIn(ids);
     }
 
+    @Override
+    public List<Member> findAll() {
+        return port.findAll();
+    }
+
+    @Override
+    public List<Member> findAllByTeamName(String teamName) {
+        return port.findAllByTeamName(teamName);
+    }
+
 }
 
 interface MemberJpaRepositoryPort extends org.springframework.data.jpa.repository.JpaRepository<Member, Long> {
-
     Optional<Member> findByEmail(String email);
-
     boolean existsByEmail(String email);
-
     List<Member> findAllByIdIn(List<Long> ids);
+    List<Member> findAllByTeamName(String teamName);
 }

--- a/src/main/resources/db/migration/V20__create_attendance_exception.sql
+++ b/src/main/resources/db/migration/V20__create_attendance_exception.sql
@@ -1,0 +1,19 @@
+CREATE TABLE attendance_exception (
+                                      id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                                      member_id           BIGINT NOT NULL REFERENCES member(member_id),
+                                      attendance_id       BIGINT REFERENCES attendance(attendance_id),
+                                      work_date           DATE NOT NULL,
+                                      type                VARCHAR(30) NOT NULL,
+                                      status              VARCHAR(20) NOT NULL,
+                                      note                TEXT,
+                                      reason              TEXT,
+                                      approved_by         VARCHAR(100),
+                                      approved_at         TIMESTAMP,
+                                      resolved_by         VARCHAR(100),
+                                      resolved_at         TIMESTAMP,
+                                      created_at          TIMESTAMP NOT NULL DEFAULT NOW(),
+                                      CONSTRAINT uk_member_workdate_type UNIQUE (member_id, work_date, type)
+);
+
+CREATE INDEX idx_attendance_exception_workdate ON attendance_exception(work_date);
+CREATE INDEX idx_attendance_exception_status ON attendance_exception(status);

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
@@ -1,0 +1,48 @@
+package com.yanus.attendance.attendance;
+
+import com.yanus.attendance.attendance.domain.exception.AttendanceException;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionRepository;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeAttendanceExceptionRepository implements AttendanceExceptionRepository {
+
+    private final Map<Long, AttendanceException> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public AttendanceException save(AttendanceException exception) {
+        if (exception.getId() == null) {
+            ReflectionTestUtils.setField(exception, "id", sequence++);
+        }
+        store.put(exception.getId(), exception);
+        return exception;
+    }
+
+    @Override
+    public Optional<AttendanceException> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public Optional<AttendanceException> findByMemberIdAndWorkDateAndType(
+            Long memberId, LocalDate workDate, AttendanceExceptionType type) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getId().equals(memberId))
+                .filter(e -> e.getWorkDate().equals(workDate))
+                .filter(e -> e.getType() == type)
+                .findFirst();
+    }
+
+    @Override
+    public List<AttendanceException> findAllByWorkDate(LocalDate workDate) {
+        return store.values().stream()
+                .filter(e -> e.getWorkDate().equals(workDate))
+                .toList();
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -1,0 +1,98 @@
+package com.yanus.attendance.attendance.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.attendance.FakeAttendanceExceptionRepository;
+import com.yanus.attendance.attendance.FakeAttendanceRepository;
+import com.yanus.attendance.attendance.FakeAttendanceSettingRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
+import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
+import com.yanus.attendance.attendance.application.setting.AttendanceSettingService;
+import com.yanus.attendance.attendance.domain.exception.AttendanceException;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.domain.Team;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class AttendanceExceptionServiceTest {
+
+    private static final LocalDate MONDAY = LocalDate.of(2026, 4, 20);
+
+    private AttendanceExceptionService service;
+    private FakeAttendanceExceptionRepository exceptionRepository;
+    private FakeAttendanceRepository attendanceRepository;
+    private FakeWorkScheduleRepository workScheduleRepository;
+    private FakeMemberRepository memberRepository;
+    private FakeAttendanceSettingRepository settingRepository;
+    private AttendanceSettingService settingService;
+
+    @BeforeEach
+    void setUp() {
+        exceptionRepository = new FakeAttendanceExceptionRepository();
+        attendanceRepository = new FakeAttendanceRepository();
+        workScheduleRepository = new FakeWorkScheduleRepository();
+        memberRepository = new FakeMemberRepository();
+        settingRepository = new FakeAttendanceSettingRepository();
+        settingService = new AttendanceSettingService(settingRepository, memberRepository);
+
+        service = new AttendanceExceptionService(
+                exceptionRepository,
+                attendanceRepository,
+                workScheduleRepository,
+                memberRepository,
+                settingService
+        );
+    }
+
+    private Member createMember(String name, String email) {
+        Team team = Team.create("1팀");
+        ReflectionTestUtils.setField(team, "id", 1L);
+        Member member = Member.create(name, email, "pw", MemberRole.MEMBER, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("조회 시 해당 날짜의 예외를 판정해 DB에 저장한다")
+    void 조회_시_해당_날짜의_예외를_판정해_DB에_저장한다() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+
+        // when
+        service.getExceptions(MONDAY, null, null, null);
+
+        // then
+        List<AttendanceException> saved = exceptionRepository.findAllByWorkDate(MONDAY);
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getType()).isEqualTo(AttendanceExceptionType.MISSED_CHECK_IN);
+    }
+
+    @Test
+    @DisplayName("같은 날짜를 두 번 조회해도 예외가 중복 생성되지 않는다")
+    void 같은_날짜를_두_번_조회해도_예외가_중복_생성되지_않는다() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
+
+        // when
+        service.getExceptions(MONDAY, null, null, null);
+        service.getExceptions(MONDAY, null, null, null);
+
+        // then
+        assertThat(exceptionRepository.findAllByWorkDate(MONDAY)).hasSize(1);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -12,6 +12,7 @@ import com.yanus.attendance.attendance.domain.exception.AttendanceException;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.presentation.dto.AttendanceExceptionSummary;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;
@@ -112,7 +113,7 @@ public class AttendanceExceptionServiceTest {
                 member3, null, MONDAY, AttendanceExceptionType.LATE));
 
         // when
-        Summary summary = service.getSummary(MONDAY);
+        AttendanceExceptionSummary summary = service.getSummary(MONDAY);
 
         // then
         assertThat(summary.totalCount()).isEqualTo(3);

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -95,4 +95,29 @@ public class AttendanceExceptionServiceTest {
         // then
         assertThat(exceptionRepository.findAllByWorkDate(MONDAY)).hasSize(1);
     }
+
+    @Test
+    @DisplayName("summary는 타입별 카운트를 집계한다")
+    void summary는_타입별_카운트를_집계한다() {
+        // given
+        Member member1 = createMember("홍길동1", "hong1@test.com");
+        Member member2 = createMember("홍길동2", "hong2@test.com");
+        Member member3 = createMember("홍길동3", "hong3@test.com");
+
+        exceptionRepository.save(AttendanceException.open(
+                member1, null, MONDAY, AttendanceExceptionType.MISSED_CHECK_IN));
+        exceptionRepository.save(AttendanceException.open(
+                member2, null, MONDAY, AttendanceExceptionType.MISSED_CHECK_IN));
+        exceptionRepository.save(AttendanceException.open(
+                member3, null, MONDAY, AttendanceExceptionType.LATE));
+
+        // when
+        Summary summary = service.getSummary(MONDAY);
+
+        // then
+        assertThat(summary.totalCount()).isEqualTo(3);
+        assertThat(summary.missedCheckInCount()).isEqualTo(2);
+        assertThat(summary.lateCount()).isEqualTo(1);
+        assertThat(summary.openCount()).isEqualTo(3);
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -3,7 +3,6 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
-import com.yanus.attendance.attendance.domain.exception.AttendanceException;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionJudge;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
@@ -108,5 +107,21 @@ public class AttendanceExceptionJudgeTest {
 
         // then
         assertThat(result).doesNotContain(AttendanceExceptionType.MISSED_CHECK_OUT);
+    }
+
+    @Test
+    @DisplayName("정상 출퇴근은 예외를 반환하지 않음")
+    void normal_attendance_not_throw_exception() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+        attendance.checkOut(LocalDateTime.of(2026, 4, 20, 18, 0));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, true);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -2,6 +2,7 @@ package com.yanus.attendance.attendance.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionJudge;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
@@ -10,6 +11,7 @@ import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRole;
 import com.yanus.attendance.member.domain.MemberStatus;
 import java.time.DayOfWeek;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -32,4 +34,18 @@ public class AttendanceExceptionJudgeTest {
 
         // then
         assertThat(result).containsExactly(AttendanceExceptionType.MISSED_CHECK_IN);
-    }}
+    }
+
+    @Test
+    @DisplayName("근무 일정이 없는데 체크인 기록이 있으면 NO_SCHEDULE 예외를 반환")
+    void no_work_schedule_but_chek_in_record_throw_NO_SCHEDULE() {
+        // given
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(null, attendance, false);
+
+        // then
+        assertThat(result).containsExactly(AttendanceExceptionType.NO_SCHEDULE);
+    }
+}

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -1,0 +1,35 @@
+package com.yanus.attendance.attendance.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionJudge;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
+import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
+import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AttendanceExceptionJudgeTest {
+
+    private final AttendanceExceptionJudge judge = new AttendanceExceptionJudge();
+    private final Member member = Member.create("홍길동", "hong@test.com", "pw", MemberRole.MEMBER, MemberStatus.ACTIVE, null);
+
+    @Test
+    @DisplayName("근무 일정이 있는데 체크인 기록이 없으면 MISSED_CHECK_IN 예외 반환")
+    void attend_schedule_but_no_check_in_record() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, null, false);
+
+        // then
+        assertThat(result).containsExactly(AttendanceExceptionType.MISSED_CHECK_IN);
+    }}

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -79,4 +79,34 @@ public class AttendanceExceptionJudgeTest {
         // then
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("퇴근이 없고 기준 시각이 지났으면 MISSED_CHECK_OUT 예외 반환")
+    void no_check_out_but_time_passed_throw_MISSED_CHECK_OUT() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, true);
+
+        // then
+        assertThat(result).containsExactly(AttendanceExceptionType.MISSED_CHECK_OUT);
+    }
+
+    @Test
+    @DisplayName("기준 시각이 지나지 않았으면 MISSED_CHECK_OUT 예외 미반환")
+    void judge_not_throw_MISSED_CHECK_OUT() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
+
+        // then
+        assertThat(result).doesNotContain(AttendanceExceptionType.MISSED_CHECK_OUT);
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.exception.AttendanceException;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionJudge;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
@@ -47,5 +48,35 @@ public class AttendanceExceptionJudgeTest {
 
         // then
         assertThat(result).containsExactly(AttendanceExceptionType.NO_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("근무 시작 시간 보다 늦게 체크인하면 LATE 예외 반환")
+    void work_schedule_time_late_check_in_throw_LATE() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 1));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
+
+        // then
+        assertThat(result).containsExactly(AttendanceExceptionType.LATE);
+    }
+
+    @Test
+    @DisplayName("근무 시작 시간과 정확히 동일하면 LATE 예외 발생하지 않음")
+    void work_schedule_time_tie_not_exception() {
+        // given
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+
+        // when
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
+
+        // then
+        assertThat(result).isEmpty();
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -119,7 +119,7 @@ public class AttendanceExceptionJudgeTest {
         attendance.checkOut(LocalDateTime.of(2026, 4, 20, 18, 0));
 
         // when
-        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, true);
+        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/com/yanus/attendance/member/FakeMemberRepository.java
+++ b/src/test/java/com/yanus/attendance/member/FakeMemberRepository.java
@@ -44,4 +44,17 @@ public class FakeMemberRepository implements MemberRepository {
                 .filter(m -> ids.contains(m.getId()))
                 .toList();
     }
+
+    @Override
+    public List<Member> findAll() {
+        return store.values().stream().toList();
+    }
+
+    @Override
+    public List<Member> findAllByTeamName(String teamName) {
+        return store.values().stream()
+                .filter(m -> m.getTeam() != null)
+                .filter(m -> teamName.equals(m.getTeam().getName()))
+                .toList();
+    }
 }


### PR DESCRIPTION
## 관련 이슈
closes #159

## 작업 내용
- `AttendanceException` 엔티티 + `AttendanceExceptionType` / `AttendanceExceptionStatus` enum 추가
- `AttendanceExceptionJudge` 순수 도메인 서비스 — 4종 예외 판정 규칙 (MISSED_CHECK_IN / MISSED_CHECK_OUT / LATE / NO_SCHEDULE)
- `AttendanceExceptionRepository` 포트 + JPA 구현체 추가
- `AttendanceExceptionService` 조회 시 lazy 생성 (멱등성 보장) + 타입 / 상태 / 팀 필터링 + summary 집계
- `GET /api/v1/attendance-exceptions` 엔드포인트 추가 (date / type / status / teamName 파라미터)
- `AttendanceExceptionListResponse` / `AttendanceExceptionResponse` / `AttendanceExceptionSummary` DTO 추가
- `V20` 마이그레이션 — `attendance_exception` 테이블 + `UNIQUE(member_id, work_date, type)` 제약
- `MemberRepository` 에 `findAll()` / `findAllByTeamName()` 추가
- 서비스 단위 테스트용 `FakeAttendanceExceptionRepository` 추가

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과