### PR TITLE
[ATT] #161 - 출퇴근 예외 일괄 자동 퇴근 + 스케줄러 정리

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
@@ -1,7 +1,7 @@
 package com.yanus.attendance.attendance.application.attendance;
 
+import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -10,10 +10,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AttendanceScheduler {
 
-    private final AttendanceService attendanceService;
+    private final AttendanceExceptionService attendanceExceptionService;
 
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void autoCheckOut() {
-        attendanceService.autoCheckOut(LocalDate.now(), LocalTime.now());
+        attendanceExceptionService.bulkAutoCheckout(LocalDate.now(), null, "system");
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -3,12 +3,14 @@ package com.yanus.attendance.attendance.application.exception;
 import com.yanus.attendance.attendance.application.setting.AttendanceSettingService;
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.domain.exception.*;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionListResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionSummary;
+import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
@@ -90,6 +92,22 @@ public class AttendanceExceptionService {
         AttendanceException exception = findException(id);
         exception.updateNote(note, reason);
         return toResponse(exception);
+    }
+
+    @Transactional
+    public BulkAutoCheckoutResponse bulkAutoCheckout(LocalDate date, List<Long> memberIds, String actor) {
+        generateMissingExceptions(date);
+        List<AttendanceException> targets = exceptionRepository
+                .findAllByWorkDateAndType(date, AttendanceExceptionType.MISSED_CHECK_OUT)
+                .stream()
+                .filter(e -> includesMember(e, memberIds))
+                .filter(e -> e.getStatus() != AttendanceExceptionStatus.RESOLVED)
+                .filter(e -> e.getAttendance() != null)
+                .toList();
+        List<Long> updatedIds = targets.stream()
+                .map(e -> autoCheckOut(e, date, actor))
+                .toList();
+        return new BulkAutoCheckoutResponse(updatedIds.size(), updatedIds);
     }
 
     private AttendanceException findException(Long id) {
@@ -223,5 +241,26 @@ public class AttendanceExceptionService {
         return (int) exceptions.stream()
                 .filter(e -> e.getStatus() == status)
                 .count();
+    }
+
+    private boolean includesMember(AttendanceException exception, List<Long> memberIds) {
+        if (memberIds == null) {
+            return true;
+        }
+        return memberIds.contains(exception.getMember().getId());
+    }
+
+    private Long autoCheckOut(AttendanceException exception, LocalDate date, String actor) {
+        Attendance attendance = exception.getAttendance();
+        closeAttendance(attendance, date);
+        exception.resolve(actor, LocalDateTime.now(), "자동 퇴근 처리");
+        return attendance.getId();
+    }
+
+    private void closeAttendance(Attendance attendance, LocalDate date) {
+        if (attendance.getStatus() != AttendanceStatus.WORKING) {
+            return;
+        }
+        attendance.checkOut(date.atTime(23, 59, 59));
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
@@ -13,4 +13,7 @@ public interface AttendanceExceptionJpaRepository extends JpaRepository<Attendan
 
     @Override
     List<AttendanceException> findAllByWorkDate(LocalDate workDate);
+
+    @Override
+    List<AttendanceException> findAllByWorkDateAndType(LocalDate workDate, AttendanceExceptionType type);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
@@ -11,4 +11,5 @@ public interface AttendanceExceptionRepository {
             Long memberId, LocalDate workDate, AttendanceExceptionType type
     );
     List<AttendanceException> findAllByWorkDate(LocalDate workDate);
+    List<AttendanceException> findAllByWorkDateAndType(LocalDate workDate, AttendanceExceptionType type);
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/BulkAutoCheckoutRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/BulkAutoCheckoutRequest.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.attendance.presentation.dto.exception;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record BulkAutoCheckoutRequest(
+        LocalDate date,
+        List<Long> memberIds
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/BulkAutoCheckoutResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/BulkAutoCheckoutResponse.java
@@ -1,0 +1,9 @@
+package com.yanus.attendance.attendance.presentation.dto.exception;
+
+import java.util.List;
+
+public record BulkAutoCheckoutResponse(
+        int processedCount,
+        List<Long> updatedIds
+) {
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/exception/AttendanceExceptionController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/exception/AttendanceExceptionController.java
@@ -7,6 +7,8 @@ import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExce
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionNoteRequest;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionUpdateRequest;
+import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutRequest;
+import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +68,15 @@ public class AttendanceExceptionController {
             @AuthenticationPrincipal Long memberId,
             @RequestBody(required = false) AttendanceExceptionNoteRequest request) {
         return attendanceExceptionService.resolve(id, resolveActor(memberId), noteOf(request));
+    }
+
+    @PostMapping("/bulk-auto-checkout")
+    public BulkAutoCheckoutResponse bulkAutoCheckout(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody BulkAutoCheckoutRequest request) {
+        return attendanceExceptionService.bulkAutoCheckout(
+                request.date(), request.memberIds(), resolveActor(memberId)
+        );
     }
 
     private String resolveActor(Long memberId) {

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
@@ -45,4 +45,12 @@ public class FakeAttendanceExceptionRepository implements AttendanceExceptionRep
                 .filter(e -> e.getWorkDate().equals(workDate))
                 .toList();
     }
+
+    @Override
+    public List<AttendanceException> findAllByWorkDateAndType(LocalDate workDate, AttendanceExceptionType type) {
+        return store.values().stream()
+                .filter(e -> e.getWorkDate().equals(workDate))
+                .filter(e -> e.getType() == type)
+                .toList();
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -9,6 +9,8 @@ import com.yanus.attendance.attendance.FakeAttendanceSettingRepository;
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
 import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
 import com.yanus.attendance.attendance.application.setting.AttendanceSettingService;
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
+import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.domain.exception.AttendanceException;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionStatus;
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
@@ -23,6 +25,7 @@ import com.yanus.attendance.member.domain.MemberStatus;
 import com.yanus.attendance.team.domain.Team;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -199,5 +202,30 @@ public class AttendanceExceptionServiceTest {
         // when & then
         assertThatThrownBy(() -> service.approve(999L, "admin", null))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("memberIds를 null로 호출하면 해당 날짜 MISSED_CHECK_OUT 전체를 처리한다")
+    void memberIds_null_process_all_missed_check_out() {
+        // given
+        Member member1 = createMember("홍길동1", "h1@test.com");
+        Member member2 = createMember("홍길동2", "h2@test.com");
+        Attendance a1 = attendanceRepository.save(
+                Attendance.checkIn(member1, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        Attendance a2 = attendanceRepository.save(
+                Attendance.checkIn(member2, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        exceptionRepository.save(AttendanceException.open(
+                member1, a1, MONDAY, AttendanceExceptionType.MISSED_CHECK_OUT));
+        exceptionRepository.save(AttendanceException.open(
+                member2, a2, MONDAY, AttendanceExceptionType.MISSED_CHECK_OUT));
+
+        // when
+        BulkAutoCheckoutResponse response = service.bulkAutoCheckout(MONDAY, null, "system");
+
+        // then
+        assertThat(response.processedCount()).isEqualTo(2);
+        assertThat(response.updatedIds()).containsExactlyInAnyOrder(a1.getId(), a2.getId());
+        assertThat(a1.getStatus()).isEqualTo(AttendanceStatus.LEFT);
+        assertThat(a1.getCheckOutTime()).isEqualTo(LocalDateTime.of(2026, 4, 20, 23, 59, 59));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -255,4 +255,22 @@ public class AttendanceExceptionServiceTest {
         assertThat(a2.getStatus()).isEqualTo(AttendanceStatus.WORKING);
     }
 
+    @Test
+    @DisplayName("이미 RESOLVED 된 예외는 재처리하지 않는다")
+    void already_resolved_error() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        Attendance attendance = attendanceRepository.save(
+                Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        AttendanceException exception = AttendanceException.open(
+                member, attendance, MONDAY, AttendanceExceptionType.MISSED_CHECK_OUT);
+        exception.resolve("system", LocalDateTime.now(), null);
+        exceptionRepository.save(exception);
+
+        // when
+        BulkAutoCheckoutResponse response = service.bulkAutoCheckout(MONDAY, null, "system");
+
+        // then
+        assertThat(response.processedCount()).isZero();
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -229,4 +229,30 @@ public class AttendanceExceptionServiceTest {
         assertThat(a1.getStatus()).isEqualTo(AttendanceStatus.LEFT);
         assertThat(a1.getCheckOutTime()).isEqualTo(LocalDateTime.of(2026, 4, 20, 23, 59, 59));
     }
+
+    @Test
+    @DisplayName("memberIds 지정 시 해당 멤버만 처리한다")
+    void memberIds_specified_process_only_specified_member() {
+        // given
+        Member member1 = createMember("홍길동1", "h1@test.com");
+        Member member2 = createMember("홍길동2", "h2@test.com");
+        Attendance a1 = attendanceRepository.save(
+                Attendance.checkIn(member1, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        Attendance a2 = attendanceRepository.save(
+                Attendance.checkIn(member2, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        exceptionRepository.save(AttendanceException.open(
+                member1, a1, MONDAY, AttendanceExceptionType.MISSED_CHECK_OUT));
+        exceptionRepository.save(AttendanceException.open(
+                member2, a2, MONDAY, AttendanceExceptionType.MISSED_CHECK_OUT));
+
+        // when
+        BulkAutoCheckoutResponse response = service.bulkAutoCheckout(
+                MONDAY, List.of(member1.getId()), "system");
+
+        // then
+        assertThat(response.processedCount()).isEqualTo(1);
+        assertThat(response.updatedIds()).containsExactly(a1.getId());
+        assertThat(a2.getStatus()).isEqualTo(AttendanceStatus.WORKING);
+    }
+
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -17,6 +17,7 @@ import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionSummary;
+import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.FakeMemberRepository;
 import com.yanus.attendance.member.domain.Member;


### PR DESCRIPTION
## 관련 이슈
closes #161

## 작업 내용
- \`AttendanceExceptionService.bulkAutoCheckout(date, memberIds, actor)\` 구현
  - 해당 날짜 \`MISSED_CHECK_OUT\` 예외 조회 → \`memberIds\` 필터 → 이미 RESOLVED 된 예외는 스킵 (멱등성)
  - 대상 \`attendance\` 를 \`status = LEFT\`, \`check_out_time = work_date + 23:59:59\` 로 갱신
  - 예외 \`status = RESOLVED\`, \`resolvedBy\` / \`resolvedAt\` 기록
- \`POST /api/v1/attendance-exceptions/bulk-auto-checkout\` 엔드포인트 추가
- \`BulkAutoCheckoutRequest\` / \`BulkAutoCheckoutResponse\` DTO 추가
- \`AttendanceExceptionRepository\` 에 \`findAllByWorkDateAndType\` 추가
- \`AttendanceScheduler\` 크론 변경 — 매분 실행 → 매일 23:59 (Asia/Seoul) 실행으로 교체
- 스케줄러가 \`AttendanceExceptionService.bulkAutoCheckout\` 만 호출하도록 정리 (비즈니스 로직 제거)
- 전날 이전 미퇴근자를 닫지 못하던 기존 \`AttendanceService.autoCheckOut()\` 메서드 제거
- \`AttendanceService\` 의 \`AttendanceSettingService\` 의존성 제거

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과