### PR TITLE
[Revert] #167 - main에 잘못 머지된 야간 근무 로직 되돌리기

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceScheduler.java
@@ -2,7 +2,6 @@ package com.yanus.attendance.attendance.application.attendance;
 
 import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,12 +10,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AttendanceScheduler {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private final AttendanceExceptionService attendanceExceptionService;
 
     @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void autoCheckOut() {
-        attendanceExceptionService.bulkAutoCheckout(LocalDate.now(KST), null, "system");
+        attendanceExceptionService.bulkAutoCheckout(LocalDate.now(), null, "system");
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
@@ -15,7 +15,6 @@ import com.yanus.attendance.member.domain.MemberRole;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,8 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AttendanceService {
 
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-
     private final AttendanceRepository attendanceRepository;
     private final MemberRepository memberRepository;
     private final AttendanceQueryRepository attendanceQueryRepository;
@@ -36,14 +33,14 @@ public class AttendanceService {
     public AttendanceResponse checkIn(Long memberId) {
         Member member = findMember(memberId);
         validateNotAlreadyCheckedIn(memberId);
-        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now(KST));
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now());
         attendanceRepository.save(attendance);
         return AttendanceResponse.from(attendance);
     }
 
     public AttendanceResponse checkOut(Long memberId) {
-        Attendance attendance = findWorkingAttendance(memberId);
-        attendance.checkOut(LocalDateTime.now(KST));
+        Attendance attendance = findTodayAttendance(memberId);
+        attendance.checkOut(LocalDateTime.now());
         return AttendanceResponse.from(attendance);
     }
 
@@ -84,7 +81,7 @@ public class AttendanceService {
         validateAttendanceIp(clientIp);
         Member member = findMember(memberId);
         validateNotAlreadyCheckedIn(memberId);
-        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now(KST));
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.now());
         attendanceRepository.save(attendance);
         return AttendanceResponse.from(attendance);
     }
@@ -127,23 +124,9 @@ public class AttendanceService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private Attendance findWorkingAttendance(Long memberId) {
-        LocalDate today = LocalDate.now(KST);
-        Attendance todays = findWorkingOn(memberId, today);
-        if (todays != null) {
-            return todays;
-        }
-        Attendance yesterdays = findWorkingOn(memberId, today.minusDays(1));
-        if (yesterdays != null) {
-            return yesterdays;
-        }
-        throw new BusinessException(ErrorCode.NOT_CHECKED_IN);
-    }
-
-    private Attendance findWorkingOn(Long memberId, LocalDate date) {
-        return attendanceRepository.findByMemberIdAndWorkDate(memberId, date)
-                .filter(attendance -> attendance.getStatus() == AttendanceStatus.WORKING)
-                .orElse(null);
+    private Attendance findTodayAttendance(Long memberId) {
+        return attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_CHECKED_IN));
     }
 
     private void validateAttendanceIp(String clientIp) {
@@ -153,7 +136,7 @@ public class AttendanceService {
     }
 
     private void validateNotAlreadyCheckedIn(Long memberId) {
-        attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now(KST))
+        attendanceRepository.findByMemberIdAndWorkDate(memberId, LocalDate.now())
                 .ifPresent(attendance -> {
                     throw new BusinessException(ErrorCode.ALREADY_CHECKED_IN);
                 });

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -18,7 +18,6 @@ import com.yanus.attendance.member.domain.MemberRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,8 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AttendanceExceptionService {
-
-    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final AttendanceExceptionRepository exceptionRepository;
     private final AttendanceRepository attendanceRepository;
@@ -108,7 +105,7 @@ public class AttendanceExceptionService {
                 .filter(e -> e.getAttendance() != null)
                 .toList();
         List<Long> updatedIds = targets.stream()
-                .map(e -> autoCheckOut(e, actor))
+                .map(e -> autoCheckOut(e, date, actor))
                 .toList();
         return new BulkAutoCheckoutResponse(updatedIds.size(), updatedIds);
     }
@@ -151,14 +148,14 @@ public class AttendanceExceptionService {
     }
 
     private void generateMissingExceptions(LocalDate date) {
+        boolean thresholdPassed = isThresholdPassed(date);
         memberRepository.findAll()
-                .forEach(member -> generateFor(member, date));
+                .forEach(member -> generateFor(member, date, thresholdPassed));
     }
 
-    private void generateFor(Member member, LocalDate date) {
+    private void generateFor(Member member, LocalDate date, boolean thresholdPassed) {
         WorkSchedule schedule = findSchedule(member, date);
         Attendance attendance = findAttendance(member, date);
-        boolean thresholdPassed = isThresholdPassed(date, schedule);
         List<AttendanceExceptionType> detected = judge.judge(schedule, attendance, thresholdPassed);
         detected.forEach(type -> saveIfAbsent(member, attendance, date, type));
     }
@@ -189,20 +186,16 @@ public class AttendanceExceptionService {
                 .isPresent();
     }
 
-    private boolean isThresholdPassed(LocalDate date, WorkSchedule schedule) {
-        LocalDateTime now = LocalDateTime.now(KST);
-        LocalDateTime deadline = deadlineOf(date, schedule);
-        return !now.isBefore(deadline);
-    }
-
-    private LocalDateTime deadlineOf(LocalDate date, WorkSchedule schedule) {
-        if (schedule == null) {
-            return date.atTime(settingService.getAutoCheckoutTimeValue());
+    private boolean isThresholdPassed(LocalDate date) {
+        LocalDate today = LocalDate.now();
+        if (date.isBefore(today)) {
+            return true;
         }
-        if (schedule.isEndsNextDay()) {
-            return date.plusDays(1).atTime(schedule.getEndTime());
+        if (date.isAfter(today)) {
+            return false;
         }
-        return date.atTime(schedule.getEndTime());
+        LocalTime threshold = settingService.getAutoCheckoutTimeValue();
+        return !LocalTime.now().isBefore(threshold);
     }
 
     private List<AttendanceException> filterExceptions(
@@ -257,41 +250,17 @@ public class AttendanceExceptionService {
         return memberIds.contains(exception.getMember().getId());
     }
 
-    private Long autoCheckOut(AttendanceException exception, String actor) {
+    private Long autoCheckOut(AttendanceException exception, LocalDate date, String actor) {
         Attendance attendance = exception.getAttendance();
-        WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
-        closeAttendance(attendance, exception.getWorkDate(), schedule);
-        exception.resolve(actor, LocalDateTime.now(KST), "자동 퇴근 처리");
+        closeAttendance(attendance, date);
+        exception.resolve(actor, LocalDateTime.now(), "자동 퇴근 처리");
         return attendance.getId();
     }
 
-    private void closeAttendance(Attendance attendance, LocalDate workDate, WorkSchedule schedule) {
+    private void closeAttendance(Attendance attendance, LocalDate date) {
         if (attendance.getStatus() != AttendanceStatus.WORKING) {
             return;
         }
-        attendance.checkOut(resolveCheckOutTime(attendance, workDate, schedule));
-    }
-
-    private LocalDateTime resolveCheckOutTime(Attendance attendance, LocalDate workDate, WorkSchedule schedule) {
-        if (isOvernight(schedule)) {
-            return workDate.plusDays(1).atTime(schedule.getEndTime());
-        }
-        return resolveDaytimeCheckOut(attendance, workDate);
-    }
-
-    private boolean isOvernight(WorkSchedule schedule) {
-        if (schedule == null) {
-            return false;
-        }
-        return schedule.isEndsNextDay();
-    }
-
-    private LocalDateTime resolveDaytimeCheckOut(Attendance attendance, LocalDate workDate) {
-        LocalTime configured = settingService.getAutoCheckoutTimeValue();
-        LocalDateTime candidate = workDate.atTime(configured);
-        if (candidate.isAfter(attendance.getCheckInTime())) {
-            return candidate;
-        }
-        return workDate.atTime(23, 59, 59);
+        attendance.checkOut(date.atTime(23, 59, 59));
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/workschedule/WorkScheduleService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/workschedule/WorkScheduleService.java
@@ -30,19 +30,16 @@ public class WorkScheduleService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
-        Optional<WorkSchedule> existing = workScheduleRepository
-                .findByMemberIdAndDayOfWeek(memberId, request.dayOfWeek());
+        Optional<WorkSchedule> existing = workScheduleRepository.findByMemberIdAndDayOfWeek(memberId, request.dayOfWeek());
 
         if (existing.isPresent()) {
-            existing.get().update(request.startTime(), request.endTime(), request.endsNextDay());
+            existing.get().update(request.startTime(), request.endTime());
             return WorkScheduleResponse.from(existing.get());
         }
 
-        WorkSchedule schedule = WorkSchedule.create(
-                member, request.dayOfWeek(),
-                request.startTime(), request.endTime(),
-                request.weekPattern(), request.endsNextDay());
+        WorkSchedule schedule = WorkSchedule.create(member, request.dayOfWeek(), request.startTime(), request.endTime(), request.weekPattern());
         workScheduleRepository.save(schedule);
+
         return WorkScheduleResponse.from(schedule);
     }
 

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -2,7 +2,6 @@ package com.yanus.attendance.attendance.domain.exception;
 
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,13 +44,9 @@ public class AttendanceExceptionJudge {
         return !hasSchedule && hasAttendance;
     }
 
-    private boolean isLate(boolean hasSchedule, boolean hasAttendance,
-                           Attendance attendance, WorkSchedule schedule) {
-        if (!hasSchedule || !hasAttendance) {
-            return false;
-        }
-        LocalDateTime scheduledStart = attendance.getWorkDate().atTime(schedule.getStartTime());
-        return attendance.getCheckInTime().isAfter(scheduledStart);
+    private boolean isLate(boolean hasSchedule, boolean hasAttendance, Attendance attendance, WorkSchedule schedule) {
+        return hasSchedule && hasAttendance
+                && attendance.getCheckInTime().toLocalTime().isAfter(schedule.getStartTime());
     }
 
     private boolean isMissedCheckout(boolean hasSchedule, boolean hasAttendance, boolean missedCheckoutThresholdPassed) {

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkSchedule.java
@@ -46,20 +46,15 @@ public class WorkSchedule {
     @Column(name = "week_pattern", nullable = false)
     private WeekPattern weekPattern;
 
-    @Column(name = "ends_next_day", nullable = false)
-    private boolean endsNextDay;
-
     public static WorkSchedule create(Member member, DayOfWeek dayOfWeek,
-                                      LocalTime startTime, LocalTime endTime,
-                                      WeekPattern weekPattern, boolean endsNextDay) {
-        validateTime(startTime, endTime, endsNextDay);
+                                      LocalTime startTime, LocalTime endTime, WeekPattern weekPattern) {
+        validateTime(startTime, endTime);
         WorkSchedule schedule = new WorkSchedule();
         schedule.member = member;
         schedule.dayOfWeek = dayOfWeek;
         schedule.startTime = startTime;
         schedule.endTime = endTime;
         schedule.weekPattern = weekPattern != null ? weekPattern : WeekPattern.EVERY;
-        schedule.endsNextDay = endsNextDay;
         return schedule;
     }
 
@@ -67,22 +62,6 @@ public class WorkSchedule {
         validateTime(startTime, endTime);
         this.startTime = startTime;
         this.endTime = endTime;
-    }
-
-    public void update(LocalTime startTime, LocalTime endTime, boolean endsNextDay) {
-        validateTime(startTime, endTime, endsNextDay);
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.endsNextDay = endsNextDay;
-    }
-
-    private static void validateTime(LocalTime startTime, LocalTime endTime, boolean endsNextDay) {
-        if (endsNextDay) {
-            return;
-        }
-        if (!endTime.isAfter(startTime)) {
-            throw new BusinessException(ErrorCode.INVALID_WORK_SCHEDULE_TIME);
-        }
     }
 
     private static void validateTime(LocalTime stateTime, LocalTime endTime) {

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/workschedule/WorkScheduleRequest.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/workschedule/WorkScheduleRequest.java
@@ -8,7 +8,6 @@ public record WorkScheduleRequest(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
-        WeekPattern weekPattern,
-        boolean endsNextDay
+        WeekPattern weekPattern
 ) {
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/workschedule/WorkScheduleResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/workschedule/WorkScheduleResponse.java
@@ -10,8 +10,7 @@ public record WorkScheduleResponse(
         DayOfWeek dayOfWeek,
         LocalTime startTime,
         LocalTime endTime,
-        WeekPattern weekPattern,
-        boolean endsNextDay
+        WeekPattern weekPattern
 ) {
     public static WorkScheduleResponse from(WorkSchedule schedule) {
         return new WorkScheduleResponse(
@@ -19,8 +18,7 @@ public record WorkScheduleResponse(
                 schedule.getDayOfWeek(),
                 schedule.getStartTime(),
                 schedule.getEndTime(),
-                schedule.getWeekPattern(),
-                schedule.isEndsNextDay()
+                schedule.getWeekPattern()
         );
     }
 }

--- a/src/main/java/com/yanus/attendance/global/config/SwaggerConfig.java
+++ b/src/main/java/com/yanus/attendance/global/config/SwaggerConfig.java
@@ -24,9 +24,9 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(new Info()
-                        .title("yANUs groupware API")
-                        .description("yANUs Groupware 백엔드 API 문서")
-                        .version("v3.0"))
+                        .title("Yanus Groupware API")
+                        .description("Yanus Groupware 백엔드 API 문서")
+                        .version("v1.0"))
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .addSecurityItem(securityRequirement);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,12 +6,6 @@ spring.application.name=attendance
 server.port=8080
 
 # =====================
-# Time Zone
-# =====================
-spring.jackson.time-zone=Asia/Seoul
-spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
-
-# =====================
 # Database
 # =====================
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/yanus}

--- a/src/main/resources/db/migration/V21__add_ends_next_day_to_work_schedule.sql
+++ b/src/main/resources/db/migration/V21__add_ends_next_day_to_work_schedule.sql
@@ -1,2 +1,0 @@
-ALTER TABLE work_schedule
-    ADD COLUMN ends_next_day BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -77,7 +77,7 @@ public class AttendanceExceptionServiceTest {
         // given
         Member member = createMember("홍길동", "hong@test.com");
         workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         service.getExceptions(MONDAY, null, null, null);
@@ -94,7 +94,7 @@ public class AttendanceExceptionServiceTest {
         // given
         Member member = createMember("홍길동", "hong@test.com");
         workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         service.getExceptions(MONDAY, null, null, null);
@@ -272,26 +272,5 @@ public class AttendanceExceptionServiceTest {
 
         // then
         assertThat(response.processedCount()).isZero();
-    }
-
-    @Test
-    void 야간_스케줄_자동_퇴근은_다음날_종료시각으로_기록된다() {
-        // given
-        Member member = createMember("김야근", "night@test.com");
-        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true));
-        Attendance attendance = attendanceRepository.save(
-                Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 22, 0)));
-        exceptionRepository.save(AttendanceException.open(
-                member, attendance, LocalDate.of(2026, 4, 20),
-                AttendanceExceptionType.MISSED_CHECK_OUT));
-
-        // when
-        service.bulkAutoCheckout(LocalDate.of(2026, 4, 20), null, "admin");
-
-        // then
-        Attendance saved = attendanceRepository
-                .findByMemberIdAndWorkDate(member.getId(), LocalDate.of(2026, 4, 20)).orElseThrow();
-        assertThat(saved.getCheckOutTime()).isEqualTo(LocalDateTime.of(2026, 4, 21, 6, 0));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -305,21 +305,4 @@ public class AttendanceServiceTest {
                         me.getId(), other.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
                 .isInstanceOf(BusinessException.class);
     }
-
-    @Test
-    @DisplayName("야간 근무 다음날 새벽 퇴근 시 전날 attendance로 퇴근")
-    void night_shift_check_out() {
-        // given
-        Member member = memberRepository.save(createMember());
-        LocalDate yesterday = LocalDate.now().minusDays(1);
-        Attendance attendance = Attendance.checkIn(member, yesterday.atTime(22, 0));
-        attendanceRepository.save(attendance);
-
-        // when
-        AttendanceResponse response = attendanceService.checkOut(member.getId());
-
-        // then
-        assertThat(response.workDate()).isEqualTo(yesterday);
-        assertThat(response.status()).isEqualTo(AttendanceStatus.LEFT);
-    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -78,7 +78,7 @@ class AttendanceSettlementServiceTest {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         workScheduleRepository.save(schedule);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 8, 55, 0));
         attendanceRepository.save(attendance);
@@ -100,7 +100,7 @@ class AttendanceSettlementServiceTest {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         workScheduleRepository.save(schedule);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 7, 59));
         attendanceRepository.save(attendance);
@@ -122,7 +122,7 @@ class AttendanceSettlementServiceTest {
         // given - 반복 일정 09:00, 이벤트로 10:00 오버라이드, 10:05 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         workScheduleRepository.save(schedule);
         WorkScheduleEvent event = WorkScheduleEvent.create(member,
                 LocalDate.of(2026, 3, 4), LocalTime.of(10, 0), LocalTime.of(19, 0));
@@ -162,7 +162,7 @@ class AttendanceSettlementServiceTest {
         // given - 일정은 있고 출근 기록 없음
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         workScheduleRepository.save(schedule);
 
         // when
@@ -182,7 +182,7 @@ class AttendanceSettlementServiceTest {
         // given - 3/4 (수) 10분 지각, 3/11 (수) 정시 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         workScheduleRepository.save(schedule);
         attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 4, 9, 10, 0)));
         attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 3, 11, 9, 0, 0)));

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleServiceTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
 import com.yanus.attendance.attendance.application.workschedule.WorkScheduleService;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
-import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.workschedule.MemberWorkScheduleResponse;
 import com.yanus.attendance.attendance.presentation.dto.workschedule.WorkScheduleRequest;
@@ -31,12 +30,11 @@ public class WorkScheduleServiceTest {
 
     private WorkScheduleService workScheduleService;
     private MemberRepository memberRepository;
-    private WorkScheduleRepository workScheduleRepository;
     private long teamIdSeq = 1L;
 
     @BeforeEach
     void setUp() {
-        workScheduleRepository = new FakeWorkScheduleRepository();
+        WorkScheduleRepository workScheduleRepository = new FakeWorkScheduleRepository();
         memberRepository = new FakeMemberRepository();
         workScheduleService = new WorkScheduleService(workScheduleRepository, memberRepository);
     }
@@ -58,7 +56,7 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0),
-                WeekPattern.EVERY, false);
+                WeekPattern.EVERY);
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
@@ -75,11 +73,11 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // then
         assertThat(response.startTime()).isEqualTo(LocalTime.of(10, 0));
@@ -92,9 +90,9 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.THURSDAY, LocalTime.of(9, 0), LocalTime.of(19, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.THURSDAY, LocalTime.of(9, 0), LocalTime.of(19, 0), WeekPattern.EVERY));
 
         // when
         List<WorkScheduleResponse> responses = workScheduleService.getMyWorkSchedules(member.getId());
@@ -109,7 +107,7 @@ public class WorkScheduleServiceTest {
         // given
         Member member = create();
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         workScheduleService.deleteWorkSchedule(member.getId(), DayOfWeek.MONDAY);
@@ -139,9 +137,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, member1.getTeam()));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -162,9 +160,9 @@ public class WorkScheduleServiceTest {
                 Member.create("김철수", "kim@naver.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team2));
 
         workScheduleService.setWorkSchedule(member1.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
         workScheduleService.setWorkSchedule(member2.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(member1.getId());
@@ -191,7 +189,7 @@ public class WorkScheduleServiceTest {
         // given
         Member admin = createMember("1팀", MemberRole.ADMIN);
         workScheduleService.setWorkSchedule(admin.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses = workScheduleService.getAllWorkSchedules(admin.getId());
@@ -206,7 +204,7 @@ public class WorkScheduleServiceTest {
         // given
         Member teamLead = createMember("1팀", MemberRole.TEAM_LEAD);
         workScheduleService.setWorkSchedule(teamLead.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -234,7 +232,7 @@ public class WorkScheduleServiceTest {
     void set_work_schedule_with_week_pattern() {
         // given
         Member member = create();
-        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.FIRST, false);
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.FIRST);
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
@@ -248,7 +246,7 @@ public class WorkScheduleServiceTest {
     void set_work_schedule_default_week_pattern() {
         // given
         Member member = create();
-        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), null, false);
+        WorkScheduleRequest request = new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), null);
 
         // when
         WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
@@ -263,7 +261,7 @@ public class WorkScheduleServiceTest {
         // given
         Member member = createMember("1팀", MemberRole.MEMBER);
         workScheduleService.setWorkSchedule(member.getId(),
-                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false));
+                new WorkScheduleRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY));
 
         // when
         List<MemberWorkScheduleResponse> responses =
@@ -284,24 +282,5 @@ public class WorkScheduleServiceTest {
         assertThatThrownBy(() -> workScheduleService.getTeamWorkSchedules(member.getId(), otherMember.getTeam().getId()))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
-    }
-
-    @Test
-    void 야간_근무_일정을_등록할_수_있다() {
-        // given
-        Member member = createMember("1팀", MemberRole.MEMBER);
-        WorkScheduleRequest request = new WorkScheduleRequest(
-                DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0),
-                WeekPattern.EVERY, true);
-
-        // when
-        WorkScheduleResponse response = workScheduleService.setWorkSchedule(member.getId(), request);
-
-        // then
-        assertThat(response.endsNextDay()).isTrue();
-        WorkSchedule saved = workScheduleRepository
-                .findByMemberIdAndDayOfWeek(member.getId(), DayOfWeek.MONDAY).orElseThrow();
-        assertThat(saved.isEndsNextDay()).isTrue();
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/AttendanceExceptionJudgeTest.java
@@ -27,7 +27,7 @@ public class AttendanceExceptionJudgeTest {
     void attend_schedule_but_no_check_in_record() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
 
         // when
         List<AttendanceExceptionType> result = judge.judge(schedule, null, false);
@@ -54,7 +54,7 @@ public class AttendanceExceptionJudgeTest {
     void work_schedule_time_late_check_in_throw_LATE() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 1));
 
         // when
@@ -69,7 +69,7 @@ public class AttendanceExceptionJudgeTest {
     void work_schedule_time_tie_not_exception() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
 
         // when
@@ -84,7 +84,7 @@ public class AttendanceExceptionJudgeTest {
     void no_check_out_but_time_passed_throw_MISSED_CHECK_OUT() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
 
         // when
@@ -99,7 +99,7 @@ public class AttendanceExceptionJudgeTest {
     void judge_not_throw_MISSED_CHECK_OUT() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
 
         // when
@@ -114,7 +114,7 @@ public class AttendanceExceptionJudgeTest {
     void normal_attendance_not_throw_exception() {
         // given
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY);
         Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
         attendance.checkOut(LocalDateTime.of(2026, 4, 20, 18, 0));
 
@@ -123,36 +123,5 @@ public class AttendanceExceptionJudgeTest {
 
         // then
         assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("야간 근무에서 시작시간보다 뒤에 체크인하면 LATE")
-    void overnight_late_check_in() {
-        // given: 월 22:00~화 06:00
-        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true);
-        // 월 22:05 체크인
-        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 22, 5));
-
-        // when
-        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
-
-        // then
-        assertThat(result).contains(AttendanceExceptionType.LATE);
-    }
-
-    @Test
-    @DisplayName("야간 근무에서 시작시간 정확히 같으면 LATE 아님")
-    void overnight_tie_not_late() {
-        // given
-        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true);
-        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 22, 0));
-
-        // when
-        List<AttendanceExceptionType> result = judge.judge(schedule, attendance, false);
-
-        // then
-        assertThat(result).doesNotContain(AttendanceExceptionType.LATE);
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/domain/WorkScheduleTest.java
@@ -3,7 +3,6 @@ package com.yanus.attendance.attendance.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.member.domain.Member;
@@ -31,7 +30,7 @@ public class WorkScheduleTest {
         LocalTime end = LocalTime.of(18, 0);
 
         // when
-        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end, null, false);
+        WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.MONDAY, start, end, null);
 
         // then
         assertThat(schedule.getDayOfWeek()).isEqualTo(DayOfWeek.MONDAY);
@@ -47,7 +46,7 @@ public class WorkScheduleTest {
 
         // when & then
         assertThatThrownBy(() ->
-                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0), null, false))
+                WorkSchedule.create(member, DayOfWeek.MONDAY, LocalTime.of(18, 0), LocalTime.of(9, 0), null))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("종료 시간");
     }
@@ -57,7 +56,7 @@ public class WorkScheduleTest {
     void update_work_schedule() {
         // given
         WorkSchedule schedule = WorkSchedule.create(createMember(), DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0), null, false);
+                LocalTime.of(9, 0), LocalTime.of(18, 0), null);
 
         // when
         schedule.update(LocalTime.of(10, 0), LocalTime.of(19, 0));
@@ -65,69 +64,5 @@ public class WorkScheduleTest {
         // then
         assertThat(schedule.getStartTime()).isEqualTo(LocalTime.of(10, 0));
         assertThat(schedule.getEndTime()).isEqualTo(LocalTime.of(19, 0));
-    }
-
-    @Test
-    @DisplayName("야간 근무는 플래그를 통해 생성 가능")
-    void night_work_schedule() {
-        // given
-        Member member = createMember();
-        LocalTime start = LocalTime.of(22, 0);
-        LocalTime end = LocalTime.of(6, 0);
-
-        // when
-        WorkSchedule schedule = WorkSchedule.create(
-                member, DayOfWeek.MONDAY, start, end, WeekPattern.EVERY, true);
-
-        // then
-        assertThat(schedule.getStartTime()).isEqualTo(start);
-        assertThat(schedule.getEndTime()).isEqualTo(end);
-        assertThat(schedule.isEndsNextDay()).isTrue();
-    }
-
-    @Test
-    @DisplayName("같은 날 종료 스케쥴은 endsNextDay_false로 생성")
-    void same_day_schedule_ends_next_day_false() {
-        // given
-        Member member = createMember();
-
-        // when
-        WorkSchedule schedule = WorkSchedule.create(
-                member, DayOfWeek.MONDAY,
-                LocalTime.of(9, 0), LocalTime.of(18, 0),
-                WeekPattern.EVERY, false);
-
-        // then
-        assertThat(schedule.isEndsNextDay()).isFalse();
-    }
-
-    @Test
-    @DisplayName("endsNextDay_false면 종료시간이 시작시간보다 빠르면 예외 발생")
-    void endsNextDay_false면_종료시간이_시작시간보다_빠르면_예외() {
-        // given
-        Member member = createMember();
-
-        // when & then
-        assertThatThrownBy(() -> WorkSchedule.create(
-                member, DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0),
-                WeekPattern.EVERY, false))
-                .isInstanceOf(BusinessException.class);
-    }
-
-    @Test
-    @DisplayName("야간 근무 수정 시 endsNextDay를 유지할 수 있다")
-    void update_overnight_schedule() {
-        // given
-        WorkSchedule schedule = WorkSchedule.create(createMember(), DayOfWeek.MONDAY,
-                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true);
-
-        // when
-        schedule.update(LocalTime.of(23, 0), LocalTime.of(7, 0), true);
-
-        // then
-        assertThat(schedule.getStartTime()).isEqualTo(LocalTime.of(23, 0));
-        assertThat(schedule.getEndTime()).isEqualTo(LocalTime.of(7, 0));
-        assertThat(schedule.isEndsNextDay()).isTrue();
     }
 }


### PR DESCRIPTION
## 배경
- `#167` PR이 원래 의도한 `feat/attendance -> dev` 가 아니라 `feat/attendance -> main` 으로 잘못 머지됨
- `main` 브랜치에는 해당 변경을 먼저 되돌리고, 이후 `dev` 브랜치로 정상 PR 흐름을 복구해야 함

## 작업 내용
- PR #167 머지 커밋 revert
- `main` 브랜치를 야간 근무 로직 반영 이전 상태로 복구
- 동일 변경사항은 별도 PR로 `feat/attendance -> dev` 에 다시 반영 예정

## 체크리스트
- [x] 잘못 머지된 커밋 확인
- [x] revert 커밋 생성
- [ ] revert PR 머지