### PR TITLE
[v4.0] #165 - 야간 근무(자정 넘김) 출퇴근 로직 추가

### DIFF
--- a/src/main/java/com/yanus/attendance/global/config/SwaggerConfig.java
+++ b/src/main/java/com/yanus/attendance/global/config/SwaggerConfig.java
@@ -26,7 +26,7 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("yANUs groupware API")
                         .description("yANUs Groupware 백엔드 API 문서")
-                        .version("v3.0"))
+                        .version("v4.0"))
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
                 .addSecurityItem(securityRequirement);
     }


### PR DESCRIPTION
## 관련 이슈
closes #165

## 작업 내용
- `WorkSchedule.endsNextDay` 필드 추가로 자정을 넘기는 야간 근무 스케줄 지원
- `WorkScheduleRequest` / `WorkScheduleResponse` 에 `endsNextDay` 필드 반영
- `V21__add_work_schedule_ends_next_day.sql` 마이그레이션 추가
- `AttendanceExceptionJudge` 의 `LATE` / `MISSED_CHECK_OUT` 판정 로직을 야간 근무 케이스까지 처리하도록 보강
- `AttendanceExceptionService.resolveCheckOutTime()` 를 스케줄 종료 시각 기준으로 계산하도록 변경
  - `endsNextDay=true` 인 경우 `workDate + 1일 + endTime` 기준으로 자동 퇴근 처리
- `AttendanceService.checkOut()` 에서 당일뿐 아니라 전날 `WORKING` 기록도 조회하도록 수정
  - 전날 체크인 후 다음날 새벽 체크아웃 시나리오 지원
- 응답 DTO에 `endsNextDay` 정보를 포함해 프론트가 종료 시각을 올바르게 조합할 수 있도록 수정
- 야간 근무/주간 근무 회귀 테스트 추가 및 기존 동작 검증

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과
