### PR TITLE
[ATT] #172 #173 - 정산/예외 응답 NO_SCHEDULE 포함 및 야간근무 필드 보강

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
@@ -9,6 +9,7 @@ import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepo
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.setting.AttendanceSettlementItemResponse;
 import com.yanus.attendance.attendance.presentation.dto.setting.AttendanceSettlementResponse;
+import com.yanus.attendance.attendance.presentation.dto.setting.ScheduledWindow;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
@@ -59,7 +60,6 @@ public class AttendanceSettlementService {
                 .collect(Collectors.toMap(Attendance::getWorkDate, a -> a));
 
         List<AttendanceSettlementItemResponse> items = start.datesUntil(end.plusDays(1))
-                .filter(date -> isScheduledDay(date, schedules, eventMap))
                 .map(date -> buildItem(date, schedules, eventMap, attendanceMap))
                 .toList();
 
@@ -80,38 +80,37 @@ public class AttendanceSettlementService {
             Map<LocalDate, WorkScheduleEvent> eventMap,
             Map<LocalDate, Attendance> attendanceMap) {
 
-        LocalTime scheduledStart;
-        LocalTime scheduledEnd;
-
-        if (eventMap.containsKey(date)) {
-            WorkScheduleEvent event = eventMap.get(date);
-            scheduledStart = event.getStartTime();
-            scheduledEnd = event.getEndTime();
-        } else {
-            WorkSchedule schedule = schedules.stream()
-                    .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
-                    .findFirst()
-                    .orElseThrow();
-            scheduledStart = schedule.getStartTime();
-            scheduledEnd = schedule.getEndTime();
+        ScheduledWindow window = resolveWindow(date, schedules, eventMap);
+        if (window == null) {
+            return AttendanceSettlementItemResponse.noSchedule(date);
         }
 
         Attendance attendance = attendanceMap.get(date);
         if (attendance == null) {
-            return new AttendanceSettlementItemResponse(
-                    date, scheduledStart, scheduledEnd, null, null, 0, 0, AttendanceSettlementStatus.ABSENT);
+            return AttendanceSettlementItemResponse.absent(date, window);
         }
 
-        int lateMinutes = calculateLateMinutes(scheduledStart, attendance);
+        int lateMinutes = calculateLateMinutes(window.start(), attendance);
         int fee = lateMinutes * FEE_PER_MINUTE;
         AttendanceSettlementStatus status = lateMinutes > 0
                 ? AttendanceSettlementStatus.LATE
                 : AttendanceSettlementStatus.ON_TIME;
 
-        return new AttendanceSettlementItemResponse(
-                date, scheduledStart, scheduledEnd,
-                attendance.getCheckInTime(), attendance.getCheckOutTime(),
-                lateMinutes, fee, status);
+        return AttendanceSettlementItemResponse.of(date, window, attendance, lateMinutes, fee, status);
+    }
+
+    private ScheduledWindow resolveWindow(LocalDate date,
+                                          List<WorkSchedule> schedules,
+                                          Map<LocalDate, WorkScheduleEvent> eventMap) {
+        if (eventMap.containsKey(date)) {
+            WorkScheduleEvent event = eventMap.get(date);
+            return new ScheduledWindow(event.getStartTime(), event.getEndTime(), false); // event 는 당일 가정
+        }
+        return schedules.stream()
+                .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
+                .findFirst()
+                .map(s -> new ScheduledWindow(s.getStartTime(), s.getEndTime(), s.isEndsNextDay()))
+                .orElse(null);
     }
 
     private int calculateLateMinutes(LocalTime scheduledStart, Attendance attendance) {
@@ -124,7 +123,9 @@ public class AttendanceSettlementService {
     private AttendanceSettlementResponse aggregate(
             Member target, YearMonth yearMonth, List<AttendanceSettlementItemResponse> items) {
 
-        int scheduledDays = items.size();
+        int scheduledDays = (int) items.stream()
+                .filter(i -> i.status() != AttendanceSettlementStatus.NO_SCHEDULE)
+                .count();
         int attendedDays = (int) items.stream()
                 .filter(i -> i.status() != AttendanceSettlementStatus.ABSENT)
                 .count();

--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
@@ -66,14 +66,6 @@ public class AttendanceSettlementService {
         return aggregate(target, yearMonth, items);
     }
 
-    private boolean isScheduledDay(LocalDate date,
-                                   List<WorkSchedule> schedules, Map<LocalDate, WorkScheduleEvent> eventMap) {
-        if (eventMap.containsKey(date)) {
-            return true;
-        }
-        return schedules.stream().anyMatch(s -> s.getDayOfWeek() == date.getDayOfWeek());
-    }
-
     private AttendanceSettlementItemResponse buildItem(
             LocalDate date,
             List<WorkSchedule> schedules,
@@ -104,7 +96,7 @@ public class AttendanceSettlementService {
                                           Map<LocalDate, WorkScheduleEvent> eventMap) {
         if (eventMap.containsKey(date)) {
             WorkScheduleEvent event = eventMap.get(date);
-            return new ScheduledWindow(event.getStartTime(), event.getEndTime(), false); // event 는 당일 가정
+            return new ScheduledWindow(event.getStartTime(), event.getEndTime(), false);
         }
         return schedules.stream()
                 .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
@@ -127,7 +119,8 @@ public class AttendanceSettlementService {
                 .filter(i -> i.status() != AttendanceSettlementStatus.NO_SCHEDULE)
                 .count();
         int attendedDays = (int) items.stream()
-                .filter(i -> i.status() != AttendanceSettlementStatus.ABSENT)
+                .filter(i -> i.status() == AttendanceSettlementStatus.ON_TIME
+                        || i.status() == AttendanceSettlementStatus.LATE)
                 .count();
         int lateDays = (int) items.stream()
                 .filter(i -> i.status() == AttendanceSettlementStatus.LATE)

--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
@@ -84,11 +84,16 @@ public class AttendanceSettlementService {
 
         int lateMinutes = calculateLateMinutes(window.start(), attendance);
         int fee = lateMinutes * FEE_PER_MINUTE;
-        AttendanceSettlementStatus status = lateMinutes > 0
-                ? AttendanceSettlementStatus.LATE
-                : AttendanceSettlementStatus.ON_TIME;
+        AttendanceSettlementStatus status = resolveStatus(lateMinutes);
 
         return AttendanceSettlementItemResponse.of(date, window, attendance, lateMinutes, fee, status);
+    }
+
+    private AttendanceSettlementStatus resolveStatus(int lateMinutes) {
+        if (lateMinutes > 0) {
+            return AttendanceSettlementStatus.LATE;
+        }
+        return AttendanceSettlementStatus.ON_TIME;
     }
 
     private ScheduledWindow resolveWindow(LocalDate date,

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -120,7 +120,12 @@ public class AttendanceExceptionService {
 
     private AttendanceExceptionResponse toResponse(AttendanceException exception) {
         WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
-        return AttendanceExceptionResponse.from(exception, startOf(schedule), endOf(schedule));
+        return AttendanceExceptionResponse.from(
+                exception,
+                startOf(schedule),
+                endOf(schedule),
+                endsNextDayOf(schedule)
+        );
     }
 
     private LocalTime startOf(WorkSchedule schedule) {
@@ -135,6 +140,13 @@ public class AttendanceExceptionService {
             return null;
         }
         return schedule.getEndTime();
+    }
+
+    private boolean endsNextDayOf(WorkSchedule schedule) {
+        if (schedule == null) {
+            return false;
+        }
+        return schedule.isEndsNextDay();
     }
 
     private AttendanceExceptionSummary buildSummary(

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
@@ -1,5 +1,5 @@
 package com.yanus.attendance.attendance.domain.attendance;
 
 public enum AttendanceSettlementStatus {
-    ON_TIME, LATE, ABSENT
+    ON_TIME, LATE, ABSENT, NO_SCHEDULE
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/AttendanceExceptionResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/AttendanceExceptionResponse.java
@@ -23,12 +23,17 @@ public record AttendanceExceptionResponse(
         Long attendanceRecordId,
         LocalTime scheduledStartTime,
         LocalTime scheduledEndTime,
+        boolean endsNextDay,
+        LocalDateTime scheduledStartAt,
+        LocalDateTime scheduledEndAt,
         LocalDateTime checkInTime,
         LocalDateTime checkOutTime
 ) {
     public static AttendanceExceptionResponse from(
             AttendanceException e,
-            LocalTime scheduledStart, LocalTime scheduledEnd) {
+            LocalTime scheduledStart,
+            LocalTime scheduledEnd,
+            boolean endsNextDay) {
         Attendance attendance = e.getAttendance();
         return new AttendanceExceptionResponse(
                 e.getId(),
@@ -47,9 +52,22 @@ public record AttendanceExceptionResponse(
                 attendanceId(attendance),
                 scheduledStart,
                 scheduledEnd,
+                endsNextDay,
+                toDateTime(e.getWorkDate(), scheduledStart, false),
+                toDateTime(e.getWorkDate(), scheduledEnd, endsNextDay),
                 checkIn(attendance),
                 checkOut(attendance)
         );
+    }
+
+    private static LocalDateTime toDateTime(LocalDate workDate, LocalTime time, boolean nextDay) {
+        if (time == null) {
+            return null;
+        }
+        if (nextDay) {
+            return workDate.plusDays(1).atTime(time);
+        }
+        return workDate.atTime(time);
     }
 
     private static Long attendanceId(Attendance attendance) {

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/AttendanceSettlementItemResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/AttendanceSettlementItemResponse.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation.dto.setting;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,10 +10,43 @@ public record AttendanceSettlementItemResponse(
         LocalDate date,
         LocalTime scheduledStartTime,
         LocalTime scheduledEndTime,
+        boolean endsNextDay,
+        LocalDateTime scheduledStartAt,
+        LocalDateTime scheduledEndAt,
         LocalDateTime checkInTime,
         LocalDateTime checkOutTime,
         int lateMinutes,
         int fee,
         AttendanceSettlementStatus status
 ) {
+    public static AttendanceSettlementItemResponse noSchedule(LocalDate date) {
+        return new AttendanceSettlementItemResponse(
+                date, null, null, false, null, null, null, null,
+                0, 0, AttendanceSettlementStatus.NO_SCHEDULE
+        );
+    }
+
+    public static AttendanceSettlementItemResponse absent(LocalDate date, ScheduledWindow window) {
+        return new AttendanceSettlementItemResponse(
+                date,
+                window.start(), window.end(), window.endsNextDay(),
+                date.atTime(window.start()),
+                window.endsNextDay() ? date.plusDays(1).atTime(window.end()) : date.atTime(window.end()),
+                null, null,
+                0, 0, AttendanceSettlementStatus.ABSENT
+        );
+    }
+
+    public static AttendanceSettlementItemResponse of(
+            LocalDate date, ScheduledWindow window, Attendance attendance,
+            int lateMinutes, int fee, AttendanceSettlementStatus status
+    ) {
+        return new AttendanceSettlementItemResponse(
+                date,
+                window.start(), window.end(), window.endsNextDay(),
+                date.atTime(window.start()),
+                window.endsNextDay() ? date.plusDays(1).atTime(window.end()) : date.atTime(window.end()),
+                attendance.getCheckInTime(), attendance.getCheckOutTime(),
+                lateMinutes, fee, status);
+    }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/ScheduledWindow.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/ScheduledWindow.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.attendance.presentation.dto.setting;
+
+import java.time.LocalTime;
+
+public record ScheduledWindow(
+        LocalTime start,
+        LocalTime end,
+        boolean endsNextDay
+) {
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -16,6 +16,8 @@ import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionStatu
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionListResponse;
+import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionSummary;
 import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutResponse;
 import com.yanus.attendance.global.exception.BusinessException;
@@ -275,7 +277,8 @@ public class AttendanceExceptionServiceTest {
     }
 
     @Test
-    void 야간_스케줄_자동_퇴근은_다음날_종료시각으로_기록된다() {
+    @DisplayName("야간 일정 자동 퇴근은 다음날 종료시간으로 기록")
+    void night_schedule_auto_checkout_to_next_day_end_time() {
         // given
         Member member = createMember("김야근", "night@test.com");
         workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
@@ -293,5 +296,25 @@ public class AttendanceExceptionServiceTest {
         Attendance saved = attendanceRepository
                 .findByMemberIdAndWorkDate(member.getId(), LocalDate.of(2026, 4, 20)).orElseThrow();
         assertThat(saved.getCheckOutTime()).isEqualTo(LocalDateTime.of(2026, 4, 21, 6, 0));
+    }
+
+    @Test
+    @DisplayName("야간근무 스케줄의 예외 응답은 endsNextDay와 datetime을 포함한다")
+    void night_work_schedule_response_has_endsNextDay_and_datetime() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true));
+
+        // when
+        AttendanceExceptionListResponse response = service.getList(MONDAY, null, null, null);
+
+        // then
+        AttendanceExceptionResponse item = response.items().get(0);
+        assertThat(item.endsNextDay()).isTrue();
+        assertThat(item.scheduledStartAt()).isEqualTo(LocalDateTime.of(2026, 4, 20, 22, 0));
+        assertThat(item.scheduledEndAt()).isEqualTo(LocalDateTime.of(2026, 4, 21, 6, 0));
+        assertThat(item.scheduledStartTime()).isEqualTo(LocalTime.of(22, 0));
+        assertThat(item.scheduledEndTime()).isEqualTo(LocalTime.of(6, 0));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -142,8 +142,8 @@ class AttendanceSettlementServiceTest {
     }
 
     @Test
-    @DisplayName("근무 일정 없는 날은 items에 포함되지 않는다")
-    void 근무_일정_없는_날은_items에_포함되지_않는다() {
+    @DisplayName("근무 일정이 없으면 모든 날짜가 NO_SCHEDULE")
+    void 근무_일정이_없으면_모든_날짜가_NO_SCHEDULE() {
         // given - 근무 일정 없음
         Member member = createMember(MemberRole.MEMBER);
 
@@ -152,7 +152,10 @@ class AttendanceSettlementServiceTest {
                 member.getId(), member.getId(), YearMonth.of(2026, 3));
 
         // then
-        assertThat(result.items()).isEmpty();
+        assertThat(result.items()).hasSize(31);
+        assertThat(result.items())
+                .allSatisfy(item -> assertThat(item.status())
+                        .isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE));
         assertThat(result.scheduledDays()).isZero();
     }
 
@@ -213,9 +216,9 @@ class AttendanceSettlementServiceTest {
     }
 
     @Test
-    @DisplayName("스케줄이_없는_날은_NO_SCHEDULE_상태로_포함")
-    void no_schedule_day_is_NO_SCHEDULE_status() {
-        // given
+    @DisplayName("스케줄이 없는 날은 NO_SCHEDULE 상태로 포함")
+    void 스케줄이_없는_날은_NO_SCHEDULE_상태로_포함() {
+        // given - 수요일만 스케줄
         Member member = createMember(MemberRole.MEMBER);
         workScheduleRepository.save(WorkSchedule.create(
                 member, DayOfWeek.WEDNESDAY,
@@ -226,10 +229,13 @@ class AttendanceSettlementServiceTest {
         AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
                 member.getId(), member.getId(), YearMonth.of(2026, 4)
         );
-        AttendanceSettlementItemResponse firstDay = result.items().get(0);
 
-        // then
-        assertThat(firstDay.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE);
+        // then - 2026-04-02 (목) 은 스케줄 없음
+        AttendanceSettlementItemResponse thursday = findItem(result, LocalDate.of(2026, 4, 2));
+        assertThat(thursday.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE);
+        assertThat(thursday.scheduledStartAt()).isNull();
+        assertThat(thursday.scheduledEndAt()).isNull();
+        assertThat(thursday.endsNextDay()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -74,7 +74,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("정시 출근은 ON_TIME이고 지각비 0원")
-    void 정시_출근은_ON_TIME이고_지각비_0원() {
+    void check_in_is_on_time_and_no_late_fee() {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -96,7 +96,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("지각 7분 59초는 7분으로 계산하고 700원")
-    void 지각_7분_59초는_7분으로_계산하고_700원() {
+    void late_7_59_seconds_is_7_minutes_and_700_fee() {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -118,7 +118,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("WorkScheduleEvent가 있으면 반복 일정보다 우선 적용")
-    void WorkScheduleEvent가_있으면_반복_일정보다_우선_적용() {
+    void work_schedule_event_is_prioritized_over_work_schedule() {
         // given - 반복 일정 09:00, 이벤트로 10:00 오버라이드, 10:05 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -143,7 +143,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("근무 일정이 없으면 모든 날짜가 NO_SCHEDULE")
-    void 근무_일정이_없으면_모든_날짜가_NO_SCHEDULE() {
+    void work_schedule_is_not_exist_then_all_days_are_no_schedule() {
         // given - 근무 일정 없음
         Member member = createMember(MemberRole.MEMBER);
 
@@ -161,7 +161,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("출근 기록 없는 날은 ABSENT이고 지각비 없음")
-    void 출근_기록_없는_날은_ABSENT이고_지각비_없음() {
+    void work_schedule_absent_day_is_absent_and_no_late_fee() {
         // given - 일정은 있고 출근 기록 없음
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -181,7 +181,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("월별 집계 정상 계산")
-    void 월별_집계_정상_계산() {
+    void monthly_settlement_calculation() {
         // given - 3/4 (수) 10분 지각, 3/11 (수) 정시 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -203,7 +203,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("MEMBER가 타인 정산 조회 시 예외")
-    void MEMBER가_타인_정산_조회_시_예외() {
+    void MEMBER_another_member_attendance_settlement_error() {
         // given
         Member me = createMember(MemberRole.MEMBER);
         Member other = createMember(MemberRole.MEMBER);
@@ -217,7 +217,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("스케줄이 없는 날은 NO_SCHEDULE 상태로 포함")
-    void 스케줄이_없는_날은_NO_SCHEDULE_상태로_포함() {
+    void no_schedule_day_is_included_in_response() {
         // given - 수요일만 스케줄
         Member member = createMember(MemberRole.MEMBER);
         workScheduleRepository.save(WorkSchedule.create(

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -229,6 +229,29 @@ class AttendanceSettlementServiceTest {
         AttendanceSettlementItemResponse firstDay = result.items().get(0);
 
         // then
-        assertThat(firstDay.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHDULE);
+        assertThat(firstDay.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE);
+    }
+
+    @Test
+    @DisplayName("야간근무 일정은 응답에 endsNextDay와 datetime을 필드로 가짐")
+    void night_work_schedule_response_has_endsNextDay_and_datetime() {
+        // given
+        Member member = createMember(MemberRole.MEMBER);
+        workScheduleRepository.save(WorkSchedule.create(
+                member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(22, 0), LocalTime.of(6, 0),
+                WeekPattern.EVERY, true));
+
+        // when
+        AttendanceSettlementResponse response =
+                settlementService.getMonthlySettlement(member.getId(), member.getId(), YearMonth.of(2026, 4));
+
+        // then
+        AttendanceSettlementItemResponse wednesday = response.items().stream()
+                .filter(i -> i.date().equals(LocalDate.of(2026, 4, 1)))
+                .findFirst().orElseThrow();
+        assertThat(wednesday.endsNextDay()).isTrue();
+        assertThat(wednesday.scheduledStartAt()).isEqualTo(LocalDateTime.of(2026, 4, 1, 22, 0));
+        assertThat(wednesday.scheduledEndAt()).isEqualTo(LocalDateTime.of(2026, 4, 2, 6, 0));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -211,4 +211,24 @@ class AttendanceSettlementServiceTest {
                         me.getId(), other.getId(), YearMonth.of(2026, 3)))
                 .isInstanceOf(BusinessException.class);
     }
+
+    @Test
+    @DisplayName("스케줄이_없는_날은_NO_SCHEDULE_상태로_포함")
+    void no_schedule_day_is_NO_SCHEDULE_status() {
+        // given
+        Member member = createMember(MemberRole.MEMBER);
+        workScheduleRepository.save(WorkSchedule.create(
+                member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false
+        ));
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 4)
+        );
+        AttendanceSettlementItemResponse firstDay = result.items().get(0);
+
+        // then
+        assertThat(firstDay.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHDULE);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
closes #172
closes #173

## 작업 내용

### #172 — 정산 응답에 스케줄 없는 날 포함
- `AttendanceSettlementStatus` enum 에 `NO_SCHEDULE` 추가
- `AttendanceSettlementService.getMonthlySettlement()` 가 근무 일정 없는 날짜도 items 에 포함하도록 변경
  - 기존 `isScheduledDay` 필터 제거 → 해당 월의 모든 날짜를 순회
  - `resolveWindow()` 에서 스케줄/이벤트 모두 없으면 `null` 반환
  - `null` window 면 `AttendanceSettlementItemResponse.noSchedule(date)` 로 `NO_SCHEDULE` 아이템 생성
- 집계 필터 정리
  - `scheduledDays` — `NO_SCHEDULE` 제외
  - `attendedDays` — `ON_TIME` / `LATE` 만 포함 (`NO_SCHEDULE` 포함되던 버그 수정)
- `AttendanceSettlementItemResponse` 에 정적 팩토리 메서드 추가 (`noSchedule` / `absent` / `of`)
- `ScheduledWindow` record 도입 (start / end / endsNextDay) — DTO 팩토리와 서비스 로직 분리

### #173 — 응답 DTO 에 야간근무 필드 추가
- `AttendanceSettlementItemResponse` 에 필드 추가
  - `boolean endsNextDay`
  - `LocalDateTime scheduledStartAt`
  - `LocalDateTime scheduledEndAt`
- `AttendanceExceptionResponse` 에 동일 필드 추가
  - `from()` 시그니처에 `boolean endsNextDay` 파라미터 추가
  - `toDateTime()` 헬퍼 — null-safe + `endsNextDay` 분기 처리
- `AttendanceExceptionService.toResponse()` 가 스케줄의 `endsNextDay` 를 DTO 로 전달
  - `endsNextDayOf(schedule)` null-safe 헬퍼 추가
- 기존 `scheduledStartTime` / `scheduledEndTime` (LocalTime) 필드는 유지 — 하위호환 보장

### 테스트
- `AttendanceSettlementServiceTest`
  - `근무_일정이_없으면_모든_날짜가_NO_SCHEDULE` — 일정 없는 멤버도 31일 items 반환
  - `스케줄이_없는_날은_NO_SCHEDULE_상태로_포함` — 스케줄 없는 요일은 `NO_SCHEDULE` 반환
  - `야간근무_일정은_응답에_endsNextDay와_datetime을_필드로_가짐` — 22:00 ~ 다음날 06:00 스케줄 필드 검증
  - 기존 `월별_집계_정상_계산` 테스트 — `attendedDays = 2` 계산 통과 확인
- `AttendanceExceptionServiceTest`
  - `야간근무 스케줄의 예외 응답은 endsNextDay와 datetime을 포함한다` — `scheduledStartAt = workDate 22:00`, `scheduledEndAt = workDate+1 06:00` 검증

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과