### PR TITLE
[v4.2] #172 #173 - 정산/예외 응답 계약 누락 복구

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceSettlementService.java
@@ -9,6 +9,7 @@ import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepo
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.setting.AttendanceSettlementItemResponse;
 import com.yanus.attendance.attendance.presentation.dto.setting.AttendanceSettlementResponse;
+import com.yanus.attendance.attendance.presentation.dto.setting.ScheduledWindow;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
@@ -59,19 +60,10 @@ public class AttendanceSettlementService {
                 .collect(Collectors.toMap(Attendance::getWorkDate, a -> a));
 
         List<AttendanceSettlementItemResponse> items = start.datesUntil(end.plusDays(1))
-                .filter(date -> isScheduledDay(date, schedules, eventMap))
                 .map(date -> buildItem(date, schedules, eventMap, attendanceMap))
                 .toList();
 
         return aggregate(target, yearMonth, items);
-    }
-
-    private boolean isScheduledDay(LocalDate date,
-                                   List<WorkSchedule> schedules, Map<LocalDate, WorkScheduleEvent> eventMap) {
-        if (eventMap.containsKey(date)) {
-            return true;
-        }
-        return schedules.stream().anyMatch(s -> s.getDayOfWeek() == date.getDayOfWeek());
     }
 
     private AttendanceSettlementItemResponse buildItem(
@@ -80,38 +72,42 @@ public class AttendanceSettlementService {
             Map<LocalDate, WorkScheduleEvent> eventMap,
             Map<LocalDate, Attendance> attendanceMap) {
 
-        LocalTime scheduledStart;
-        LocalTime scheduledEnd;
-
-        if (eventMap.containsKey(date)) {
-            WorkScheduleEvent event = eventMap.get(date);
-            scheduledStart = event.getStartTime();
-            scheduledEnd = event.getEndTime();
-        } else {
-            WorkSchedule schedule = schedules.stream()
-                    .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
-                    .findFirst()
-                    .orElseThrow();
-            scheduledStart = schedule.getStartTime();
-            scheduledEnd = schedule.getEndTime();
+        ScheduledWindow window = resolveWindow(date, schedules, eventMap);
+        if (window == null) {
+            return AttendanceSettlementItemResponse.noSchedule(date);
         }
 
         Attendance attendance = attendanceMap.get(date);
         if (attendance == null) {
-            return new AttendanceSettlementItemResponse(
-                    date, scheduledStart, scheduledEnd, null, null, 0, 0, AttendanceSettlementStatus.ABSENT);
+            return AttendanceSettlementItemResponse.absent(date, window);
         }
 
-        int lateMinutes = calculateLateMinutes(scheduledStart, attendance);
+        int lateMinutes = calculateLateMinutes(window.start(), attendance);
         int fee = lateMinutes * FEE_PER_MINUTE;
-        AttendanceSettlementStatus status = lateMinutes > 0
-                ? AttendanceSettlementStatus.LATE
-                : AttendanceSettlementStatus.ON_TIME;
+        AttendanceSettlementStatus status = resolveStatus(lateMinutes);
 
-        return new AttendanceSettlementItemResponse(
-                date, scheduledStart, scheduledEnd,
-                attendance.getCheckInTime(), attendance.getCheckOutTime(),
-                lateMinutes, fee, status);
+        return AttendanceSettlementItemResponse.of(date, window, attendance, lateMinutes, fee, status);
+    }
+
+    private AttendanceSettlementStatus resolveStatus(int lateMinutes) {
+        if (lateMinutes > 0) {
+            return AttendanceSettlementStatus.LATE;
+        }
+        return AttendanceSettlementStatus.ON_TIME;
+    }
+
+    private ScheduledWindow resolveWindow(LocalDate date,
+                                          List<WorkSchedule> schedules,
+                                          Map<LocalDate, WorkScheduleEvent> eventMap) {
+        if (eventMap.containsKey(date)) {
+            WorkScheduleEvent event = eventMap.get(date);
+            return new ScheduledWindow(event.getStartTime(), event.getEndTime(), false);
+        }
+        return schedules.stream()
+                .filter(s -> s.getDayOfWeek() == date.getDayOfWeek())
+                .findFirst()
+                .map(s -> new ScheduledWindow(s.getStartTime(), s.getEndTime(), s.isEndsNextDay()))
+                .orElse(null);
     }
 
     private int calculateLateMinutes(LocalTime scheduledStart, Attendance attendance) {
@@ -124,9 +120,12 @@ public class AttendanceSettlementService {
     private AttendanceSettlementResponse aggregate(
             Member target, YearMonth yearMonth, List<AttendanceSettlementItemResponse> items) {
 
-        int scheduledDays = items.size();
+        int scheduledDays = (int) items.stream()
+                .filter(i -> i.status() != AttendanceSettlementStatus.NO_SCHEDULE)
+                .count();
         int attendedDays = (int) items.stream()
-                .filter(i -> i.status() != AttendanceSettlementStatus.ABSENT)
+                .filter(i -> i.status() == AttendanceSettlementStatus.ON_TIME
+                        || i.status() == AttendanceSettlementStatus.LATE)
                 .count();
         int lateDays = (int) items.stream()
                 .filter(i -> i.status() == AttendanceSettlementStatus.LATE)

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -120,7 +120,12 @@ public class AttendanceExceptionService {
 
     private AttendanceExceptionResponse toResponse(AttendanceException exception) {
         WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
-        return AttendanceExceptionResponse.from(exception, startOf(schedule), endOf(schedule));
+        return AttendanceExceptionResponse.from(
+                exception,
+                startOf(schedule),
+                endOf(schedule),
+                endsNextDayOf(schedule)
+        );
     }
 
     private LocalTime startOf(WorkSchedule schedule) {
@@ -135,6 +140,13 @@ public class AttendanceExceptionService {
             return null;
         }
         return schedule.getEndTime();
+    }
+
+    private boolean endsNextDayOf(WorkSchedule schedule) {
+        if (schedule == null) {
+            return false;
+        }
+        return schedule.isEndsNextDay();
     }
 
     private AttendanceExceptionSummary buildSummary(

--- a/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/attendance/AttendanceSettlementStatus.java
@@ -1,5 +1,5 @@
 package com.yanus.attendance.attendance.domain.attendance;
 
 public enum AttendanceSettlementStatus {
-    ON_TIME, LATE, ABSENT
+    ON_TIME, LATE, ABSENT, NO_SCHEDULE
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/AttendanceExceptionResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/exception/AttendanceExceptionResponse.java
@@ -23,12 +23,17 @@ public record AttendanceExceptionResponse(
         Long attendanceRecordId,
         LocalTime scheduledStartTime,
         LocalTime scheduledEndTime,
+        boolean endsNextDay,
+        LocalDateTime scheduledStartAt,
+        LocalDateTime scheduledEndAt,
         LocalDateTime checkInTime,
         LocalDateTime checkOutTime
 ) {
     public static AttendanceExceptionResponse from(
             AttendanceException e,
-            LocalTime scheduledStart, LocalTime scheduledEnd) {
+            LocalTime scheduledStart,
+            LocalTime scheduledEnd,
+            boolean endsNextDay) {
         Attendance attendance = e.getAttendance();
         return new AttendanceExceptionResponse(
                 e.getId(),
@@ -47,9 +52,22 @@ public record AttendanceExceptionResponse(
                 attendanceId(attendance),
                 scheduledStart,
                 scheduledEnd,
+                endsNextDay,
+                toDateTime(e.getWorkDate(), scheduledStart, false),
+                toDateTime(e.getWorkDate(), scheduledEnd, endsNextDay),
                 checkIn(attendance),
                 checkOut(attendance)
         );
+    }
+
+    private static LocalDateTime toDateTime(LocalDate workDate, LocalTime time, boolean nextDay) {
+        if (time == null) {
+            return null;
+        }
+        if (nextDay) {
+            return workDate.plusDays(1).atTime(time);
+        }
+        return workDate.atTime(time);
     }
 
     private static Long attendanceId(Attendance attendance) {

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/AttendanceSettlementItemResponse.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/AttendanceSettlementItemResponse.java
@@ -1,5 +1,6 @@
 package com.yanus.attendance.attendance.presentation.dto.setting;
 
+import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceSettlementStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,10 +10,43 @@ public record AttendanceSettlementItemResponse(
         LocalDate date,
         LocalTime scheduledStartTime,
         LocalTime scheduledEndTime,
+        boolean endsNextDay,
+        LocalDateTime scheduledStartAt,
+        LocalDateTime scheduledEndAt,
         LocalDateTime checkInTime,
         LocalDateTime checkOutTime,
         int lateMinutes,
         int fee,
         AttendanceSettlementStatus status
 ) {
+    public static AttendanceSettlementItemResponse noSchedule(LocalDate date) {
+        return new AttendanceSettlementItemResponse(
+                date, null, null, false, null, null, null, null,
+                0, 0, AttendanceSettlementStatus.NO_SCHEDULE
+        );
+    }
+
+    public static AttendanceSettlementItemResponse absent(LocalDate date, ScheduledWindow window) {
+        return new AttendanceSettlementItemResponse(
+                date,
+                window.start(), window.end(), window.endsNextDay(),
+                date.atTime(window.start()),
+                window.endsNextDay() ? date.plusDays(1).atTime(window.end()) : date.atTime(window.end()),
+                null, null,
+                0, 0, AttendanceSettlementStatus.ABSENT
+        );
+    }
+
+    public static AttendanceSettlementItemResponse of(
+            LocalDate date, ScheduledWindow window, Attendance attendance,
+            int lateMinutes, int fee, AttendanceSettlementStatus status
+    ) {
+        return new AttendanceSettlementItemResponse(
+                date,
+                window.start(), window.end(), window.endsNextDay(),
+                date.atTime(window.start()),
+                window.endsNextDay() ? date.plusDays(1).atTime(window.end()) : date.atTime(window.end()),
+                attendance.getCheckInTime(), attendance.getCheckOutTime(),
+                lateMinutes, fee, status);
+    }
 }

--- a/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/ScheduledWindow.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/dto/setting/ScheduledWindow.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.attendance.presentation.dto.setting;
+
+import java.time.LocalTime;
+
+public record ScheduledWindow(
+        LocalTime start,
+        LocalTime end,
+        boolean endsNextDay
+) {
+}

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -16,6 +16,8 @@ import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionStatu
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionListResponse;
+import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionSummary;
 import com.yanus.attendance.attendance.presentation.dto.exception.BulkAutoCheckoutResponse;
 import com.yanus.attendance.global.exception.BusinessException;
@@ -272,5 +274,47 @@ public class AttendanceExceptionServiceTest {
 
         // then
         assertThat(response.processedCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("야간 일정 자동 퇴근은 다음날 종료시간으로 기록")
+    void night_schedule_auto_checkout_to_next_day_end_time() {
+        // given
+        Member member = createMember("김야근", "night@test.com");
+        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true));
+        Attendance attendance = attendanceRepository.save(
+                Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 22, 0)));
+        exceptionRepository.save(AttendanceException.open(
+                member, attendance, LocalDate.of(2026, 4, 20),
+                AttendanceExceptionType.MISSED_CHECK_OUT));
+
+        // when
+        service.bulkAutoCheckout(LocalDate.of(2026, 4, 20), null, "admin");
+
+        // then
+        Attendance saved = attendanceRepository
+                .findByMemberIdAndWorkDate(member.getId(), LocalDate.of(2026, 4, 20)).orElseThrow();
+        assertThat(saved.getCheckOutTime()).isEqualTo(LocalDateTime.of(2026, 4, 21, 6, 0));
+    }
+
+    @Test
+    @DisplayName("야간근무 스케줄의 예외 응답은 endsNextDay와 datetime을 포함한다")
+    void night_work_schedule_response_has_endsNextDay_and_datetime() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleRepository.save(WorkSchedule.create(member, DayOfWeek.MONDAY,
+                LocalTime.of(22, 0), LocalTime.of(6, 0), WeekPattern.EVERY, true));
+
+        // when
+        AttendanceExceptionListResponse response = service.getList(MONDAY, null, null, null);
+
+        // then
+        AttendanceExceptionResponse item = response.items().get(0);
+        assertThat(item.endsNextDay()).isTrue();
+        assertThat(item.scheduledStartAt()).isEqualTo(LocalDateTime.of(2026, 4, 20, 22, 0));
+        assertThat(item.scheduledEndAt()).isEqualTo(LocalDateTime.of(2026, 4, 21, 6, 0));
+        assertThat(item.scheduledStartTime()).isEqualTo(LocalTime.of(22, 0));
+        assertThat(item.scheduledEndTime()).isEqualTo(LocalTime.of(6, 0));
     }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceSettlementServiceTest.java
@@ -74,7 +74,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("정시 출근은 ON_TIME이고 지각비 0원")
-    void 정시_출근은_ON_TIME이고_지각비_0원() {
+    void check_in_is_on_time_and_no_late_fee() {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -96,7 +96,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("지각 7분 59초는 7분으로 계산하고 700원")
-    void 지각_7분_59초는_7분으로_계산하고_700원() {
+    void late_7_59_seconds_is_7_minutes_and_700_fee() {
         // given - 2026-03-04 (수요일)
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -118,7 +118,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("WorkScheduleEvent가 있으면 반복 일정보다 우선 적용")
-    void WorkScheduleEvent가_있으면_반복_일정보다_우선_적용() {
+    void work_schedule_event_is_prioritized_over_work_schedule() {
         // given - 반복 일정 09:00, 이벤트로 10:00 오버라이드, 10:05 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -142,8 +142,8 @@ class AttendanceSettlementServiceTest {
     }
 
     @Test
-    @DisplayName("근무 일정 없는 날은 items에 포함되지 않는다")
-    void 근무_일정_없는_날은_items에_포함되지_않는다() {
+    @DisplayName("근무 일정이 없으면 모든 날짜가 NO_SCHEDULE")
+    void work_schedule_is_not_exist_then_all_days_are_no_schedule() {
         // given - 근무 일정 없음
         Member member = createMember(MemberRole.MEMBER);
 
@@ -152,13 +152,16 @@ class AttendanceSettlementServiceTest {
                 member.getId(), member.getId(), YearMonth.of(2026, 3));
 
         // then
-        assertThat(result.items()).isEmpty();
+        assertThat(result.items()).hasSize(31);
+        assertThat(result.items())
+                .allSatisfy(item -> assertThat(item.status())
+                        .isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE));
         assertThat(result.scheduledDays()).isZero();
     }
 
     @Test
     @DisplayName("출근 기록 없는 날은 ABSENT이고 지각비 없음")
-    void 출근_기록_없는_날은_ABSENT이고_지각비_없음() {
+    void work_schedule_absent_day_is_absent_and_no_late_fee() {
         // given - 일정은 있고 출근 기록 없음
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -178,7 +181,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("월별 집계 정상 계산")
-    void 월별_집계_정상_계산() {
+    void monthly_settlement_calculation() {
         // given - 3/4 (수) 10분 지각, 3/11 (수) 정시 출근
         Member member = createMember(MemberRole.MEMBER);
         WorkSchedule schedule = WorkSchedule.create(member, DayOfWeek.WEDNESDAY,
@@ -200,7 +203,7 @@ class AttendanceSettlementServiceTest {
 
     @Test
     @DisplayName("MEMBER가 타인 정산 조회 시 예외")
-    void MEMBER가_타인_정산_조회_시_예외() {
+    void MEMBER_another_member_attendance_settlement_error() {
         // given
         Member me = createMember(MemberRole.MEMBER);
         Member other = createMember(MemberRole.MEMBER);
@@ -210,5 +213,51 @@ class AttendanceSettlementServiceTest {
                 settlementService.getMonthlySettlement(
                         me.getId(), other.getId(), YearMonth.of(2026, 3)))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("스케줄이 없는 날은 NO_SCHEDULE 상태로 포함")
+    void no_schedule_day_is_included_in_response() {
+        // given - 수요일만 스케줄
+        Member member = createMember(MemberRole.MEMBER);
+        workScheduleRepository.save(WorkSchedule.create(
+                member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(9, 0), LocalTime.of(18, 0), WeekPattern.EVERY, false
+        ));
+
+        // when
+        AttendanceSettlementResponse result = settlementService.getMonthlySettlement(
+                member.getId(), member.getId(), YearMonth.of(2026, 4)
+        );
+
+        // then - 2026-04-02 (목) 은 스케줄 없음
+        AttendanceSettlementItemResponse thursday = findItem(result, LocalDate.of(2026, 4, 2));
+        assertThat(thursday.status()).isEqualTo(AttendanceSettlementStatus.NO_SCHEDULE);
+        assertThat(thursday.scheduledStartAt()).isNull();
+        assertThat(thursday.scheduledEndAt()).isNull();
+        assertThat(thursday.endsNextDay()).isFalse();
+    }
+
+    @Test
+    @DisplayName("야간근무 일정은 응답에 endsNextDay와 datetime을 필드로 가짐")
+    void night_work_schedule_response_has_endsNextDay_and_datetime() {
+        // given
+        Member member = createMember(MemberRole.MEMBER);
+        workScheduleRepository.save(WorkSchedule.create(
+                member, DayOfWeek.WEDNESDAY,
+                LocalTime.of(22, 0), LocalTime.of(6, 0),
+                WeekPattern.EVERY, true));
+
+        // when
+        AttendanceSettlementResponse response =
+                settlementService.getMonthlySettlement(member.getId(), member.getId(), YearMonth.of(2026, 4));
+
+        // then
+        AttendanceSettlementItemResponse wednesday = response.items().stream()
+                .filter(i -> i.date().equals(LocalDate.of(2026, 4, 1)))
+                .findFirst().orElseThrow();
+        assertThat(wednesday.endsNextDay()).isTrue();
+        assertThat(wednesday.scheduledStartAt()).isEqualTo(LocalDateTime.of(2026, 4, 1, 22, 0));
+        assertThat(wednesday.scheduledEndAt()).isEqualTo(LocalDateTime.of(2026, 4, 2, 6, 0));
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #172
- #173

## 배경
- `v4.1` 에서 정산/예외 응답 계약 보강이 `main` 에 반영되었지만,
  이후 `dev` 브랜치에서는 해당 반영분이 되돌려지면서 `main` 과 `dev` 의 상태가 다시 어긋났습니다.
- 이번 PR은 `dev` 에서 누락된 응답 계약 보강을 다시 복구해, 브랜치 상태를 일치시키기 위한 릴리즈입니다.

## 작업 내용
- `AttendanceExceptionResponse` 계약 복구
  - `boolean endsNextDay`
  - `LocalDateTime scheduledStartAt`
  - `LocalDateTime scheduledEndAt`
- `AttendanceExceptionService.toResponse()` 에서 스케줄의 `endsNextDay` 를 DTO 로 전달하도록 복구
- `AttendanceSettlementStatus` 에 `NO_SCHEDULE` 복구
- `AttendanceSettlementItemResponse` 계약 복구
  - `boolean endsNextDay`
  - `LocalDateTime scheduledStartAt`
  - `LocalDateTime scheduledEndAt`
  - 정적 팩토리 메서드 `noSchedule(...)`, `absent(...)`, `of(...)`
- `ScheduledWindow` record 복구
- `AttendanceSettlementService` 동작 복구
  - 스케줄 없는 날짜를 `NO_SCHEDULE` 로 반환
  - 야간근무 종료 시각을 `scheduledEndAt` 기준으로 계산
  - 집계 시 `NO_SCHEDULE` 제외 규칙 유지
- 관련 서비스 테스트 복구
  - `AttendanceExceptionServiceTest`
  - `AttendanceSettlementServiceTest`

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과

## 검증
- `./gradlew test --tests "com.yanus.attendance.attendance.application.AttendanceExceptionServiceTest" --tests "com.yanus.attendance.attendance.application.AttendanceSettlementServiceTest"`
