### PR TITLE
[Bug] #184 - 출근 내역 초기화 API KST 타임존 버그 수정

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/presentation/attendance/AttendanceController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/attendance/AttendanceController.java
@@ -7,6 +7,7 @@ import com.yanus.attendance.attendance.presentation.dto.attendance.AttendanceRes
 import com.yanus.attendance.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -25,6 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/attendances")
 @RequiredArgsConstructor
 public class AttendanceController {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final AttendanceService attendanceService;
 
@@ -70,12 +73,9 @@ public class AttendanceController {
     public ResponseEntity<Void> resetAttendance(
             @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
-        LocalDate targetDate = null;
-        if (date != null) {
-            targetDate = date;
-        }
-        if (date == null) {
-            targetDate = LocalDate.now();
+        LocalDate targetDate = date;
+        if (targetDate == null) {
+            targetDate = LocalDate.now(KST);
         }
         attendanceService.resetAttendance(memberId, targetDate);
         return ResponseEntity.noContent().build();

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -25,6 +25,7 @@ import com.yanus.attendance.team.domain.Team;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public class AttendanceServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private AttendanceService attendanceService;
     private AttendanceRepository attendanceRepository;
@@ -137,7 +140,7 @@ public class AttendanceServiceTest {
     void get_attendances_by_date() {
         // given
         Member member = createMember();
-        LocalDate date = LocalDateTime.now().toLocalDate();
+        LocalDate date = LocalDate.now(KST);
         attendanceService.checkIn(member.getId());
 
         // when
@@ -152,7 +155,7 @@ public class AttendanceServiceTest {
     void get_attendances_by_filter_with_team() {
         // given
         Member member = createMember();
-        LocalDate date = LocalDate.now();
+        LocalDate date = LocalDate.now(KST);
         attendanceService.checkIn(member.getId());
 
         // when
@@ -167,7 +170,7 @@ public class AttendanceServiceTest {
     void get_attendances_by_filter_without_team() {
         // given
         Member member = createMember();
-        LocalDate date = LocalDate.now();
+        LocalDate date = LocalDate.now(KST);
         attendanceService.checkIn(member.getId());
 
         // when
@@ -182,7 +185,7 @@ public class AttendanceServiceTest {
     void auto_check_out() {
         // given
         Member member = createMember();
-        LocalDate date = LocalDate.now();
+        LocalDate date = LocalDate.now(KST);
         attendanceService.checkIn(member.getId());
 
         // when
@@ -227,7 +230,7 @@ public class AttendanceServiceTest {
         attendanceService.checkIn(member.getId(), "220.69.1.1");
 
         // when
-        attendanceService.resetAttendance(member.getId(), LocalDate.now());
+        attendanceService.resetAttendance(member.getId(), LocalDate.now(KST));
 
         // then
         assertThat(attendanceService.getMyAttendances(member.getId())).isEmpty();
@@ -240,7 +243,7 @@ public class AttendanceServiceTest {
         Member member = createMember();
 
         // when & then
-        assertThatThrownBy(() -> attendanceService.resetAttendance(member.getId(), LocalDate.now()))
+        assertThatThrownBy(() -> attendanceService.resetAttendance(member.getId(), LocalDate.now(KST)))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ATTENDANCE_NOT_FOUND);
     }
@@ -311,7 +314,7 @@ public class AttendanceServiceTest {
     void night_shift_check_out() {
         // given
         Member member = memberRepository.save(createMember());
-        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDate yesterday = LocalDate.now(KST).minusDays(1);
         Attendance attendance = Attendance.checkIn(member, yesterday.atTime(22, 0));
         attendanceRepository.save(attendance);
 


### PR DESCRIPTION
## 관련 이슈
closes #184

## 작업 내용
- `AttendanceController.resetAttendance` 기본 날짜를 `LocalDate.now(KST)` 기준으로 변경
- 컨트롤러에 `private static final ZoneId KST = ZoneId.of("Asia/Seoul");` 추가
- `null` 재할당 패턴 정리
- `AttendanceServiceTest` 7군데 `LocalDate.now()` / `LocalDateTime.now().toLocalDate()` 를 `LocalDate.now(KST)` 로 통일하여 CI(UTC) 환경 회귀 수정

## 체크리스트
- [x] 테스트 작성 (Red) — CI 로그 (231 tests, 6 failed) 로 증명
- [x] 기능 구현 (Green) — `TZ=UTC -Duser.timezone=UTC ./gradlew test` 로 BUILD SUCCESSFUL 확인
- [x] 리팩터링 완료
- [x] 테스트 전체 통과