### PR TITLE
[v4.5] #187 - 출근 내역 초기화 시 FK 제약 위반으로 500 나는 버그 수정

### DIFF
--- a/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/attendance/AttendanceService.java
@@ -5,6 +5,7 @@ import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceQueryRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionRepository;
 import com.yanus.attendance.attendance.presentation.dto.attendance.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.attendance.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
@@ -32,6 +33,7 @@ public class AttendanceService {
     private final MemberRepository memberRepository;
     private final AttendanceQueryRepository attendanceQueryRepository;
     private final AttendanceSettingService attendanceSettingService;
+    private final AttendanceExceptionRepository attendanceExceptionRepository;
 
     public AttendanceResponse checkIn(Long memberId) {
         Member member = findMember(memberId);
@@ -92,6 +94,7 @@ public class AttendanceService {
     public void resetAttendance(Long memberId, LocalDate today) {
         Attendance attendance = attendanceRepository.findByMemberIdAndWorkDate(memberId, today)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ATTENDANCE_NOT_FOUND));
+        attendanceExceptionRepository.deleteAllByAttendanceId(attendance.getId());
         attendanceRepository.delete(attendance);
     }
 

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJpaRepository.java
@@ -16,4 +16,7 @@ public interface AttendanceExceptionJpaRepository extends JpaRepository<Attendan
 
     @Override
     List<AttendanceException> findAllByWorkDateAndType(LocalDate workDate, AttendanceExceptionType type);
+
+    @Override
+    void deleteAllByAttendanceId(Long attendanceId);
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionRepository.java
@@ -12,4 +12,5 @@ public interface AttendanceExceptionRepository {
     );
     List<AttendanceException> findAllByWorkDate(LocalDate workDate);
     List<AttendanceException> findAllByWorkDateAndType(LocalDate workDate, AttendanceExceptionType type);
+    void deleteAllByAttendanceId(Long attendanceId);
 }

--- a/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeAttendanceExceptionRepository.java
@@ -53,4 +53,11 @@ public class FakeAttendanceExceptionRepository implements AttendanceExceptionRep
                 .filter(e -> e.getType() == type)
                 .toList();
     }
+
+    @Override
+    public void deleteAllByAttendanceId(Long attendanceId) {
+        store.values().removeIf(e ->
+                e.getAttendance() != null
+                        && attendanceId.equals(e.getAttendance().getId()));
+    }
 }

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.yanus.attendance.attendance.FakeAttendanceExceptionRepository;
 import com.yanus.attendance.attendance.FakeAttendanceQueryRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
 import com.yanus.attendance.attendance.FakeAttendanceSettingRepository;
@@ -12,6 +13,9 @@ import com.yanus.attendance.attendance.application.setting.AttendanceSettingServ
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
+import com.yanus.attendance.attendance.domain.exception.AttendanceException;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionRepository;
+import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.presentation.dto.attendance.AttendanceRangeResponse;
 import com.yanus.attendance.attendance.presentation.dto.attendance.AttendanceResponse;
 import com.yanus.attendance.global.exception.BusinessException;
@@ -42,6 +46,7 @@ public class AttendanceServiceTest {
     private MemberRepository memberRepository;
     private FakeAttendanceQueryRepository attendanceQueryRepository;
     private AttendanceSettingService settingService;
+    private AttendanceExceptionRepository exceptionRepository;
 
     private final AtomicLong memberEmailSeq = new AtomicLong(1);
     private final AtomicLong teamIdSeq = new AtomicLong(1);
@@ -52,7 +57,14 @@ public class AttendanceServiceTest {
         memberRepository = new FakeMemberRepository();
         settingService = new AttendanceSettingService(new FakeAttendanceSettingRepository(), memberRepository);
         attendanceQueryRepository = new FakeAttendanceQueryRepository(attendanceRepository);
-        attendanceService = new AttendanceService(attendanceRepository, memberRepository, attendanceQueryRepository, settingService);
+        exceptionRepository = new FakeAttendanceExceptionRepository();
+        attendanceService = new AttendanceService(
+                attendanceRepository,
+                memberRepository,
+                attendanceQueryRepository,
+                settingService,
+                exceptionRepository
+        );
         memberEmailSeq.set(1);
         teamIdSeq.set(1);
     }
@@ -324,5 +336,25 @@ public class AttendanceServiceTest {
         // then
         assertThat(response.workDate()).isEqualTo(yesterday);
         assertThat(response.status()).isEqualTo(AttendanceStatus.LEFT);
+    }
+
+    @Test
+    @DisplayName("연결된 attendance_exception 이 있어도 출근 기록 초기화에 성공한다")
+    void reset_attendance_with_linked_exception_success() {
+        // given
+        Member member = createMember();
+        LocalDate today = LocalDate.now(KST);
+        attendanceService.checkIn(member.getId(), "220.69.1.1");
+        Attendance attendance = attendanceRepository.findByMemberIdAndWorkDate(member.getId(), today)
+                .orElseThrow();
+        exceptionRepository.save(AttendanceException.open(
+                member, attendance, today, AttendanceExceptionType.MISSED_CHECK_OUT));
+
+        // when
+        attendanceService.resetAttendance(member.getId(), today);
+
+        // then
+        assertThat(attendanceService.getMyAttendances(member.getId())).isEmpty();
+        assertThat(exceptionRepository.findAllByWorkDate(today)).isEmpty();
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #187

## 작업 내용
- `DELETE /api/v1/attendances/me` 가 연결된 `attendance_exception` 때문에 500 으로 떨어지던 버그 수정
- cascade 삭제 정책으로 처리 (attendance + 연결 예외 모두 제거)
- `AttendanceExceptionRepository.deleteAllByAttendanceId` 신규
- 회귀 테스트 추가

## 프론트 작업 필요
- reset 응답에 `ATTENDANCE_NOT_FOUND` 에러 코드 처리 추가

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과