### PR TITLE
[Bug] #191 - 날짜별 근무 일정 예외 판정 및 팀 조회 반영

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1292,6 +1292,22 @@ schedules.stream()
 
 ---
 
+## 3. 날짜별 근무 일정이 예외 판정과 팀 조회에 반영되지 않음 (#191)
+
+**증상**
+날짜별 근무 일정만 추가한 날짜가 출퇴근 예외 조회에서 근무일로 반영되지 않고 `NO_SCHEDULE`로 처리될 수 있음.
+또한 본인 날짜별 일정 조회 API만 있어 팀원/관리자 화면에서 다른 사람의 날짜별 일정이 보이지 않음.
+
+**원인**
+`AttendanceExceptionService`가 반복 일정(`WorkSchedule`)만 조회하고 날짜별 일정(`WorkScheduleEvent`)을 보지 않았음.
+`WorkScheduleEventService`에도 팀/전체 조회 유스케이스가 없었음.
+
+**해결**
+예외 판정 시 날짜별 일정을 반복 일정보다 우선 적용하도록 `WorkScheduleEventRepository`를 주입하고,
+팀/전체 날짜별 일정 조회 API를 추가함.
+
+---
+
 # AUTH 도메인
 
 ## 1. 비활성화(INACTIVE) 멤버 로그인 차단 누락 (#88)

--- a/docs/troubleshooting/work-schedule.md
+++ b/docs/troubleshooting/work-schedule.md
@@ -36,3 +36,19 @@ schedules.stream()
     .map(entry -> new MemberWorkScheduleResponse(...))
     .toList();
 ```
+
+---
+
+### 3. 날짜별 근무 일정이 예외 판정과 팀 조회에 반영되지 않음 (#191)
+
+**증상**
+날짜별 근무 일정만 추가한 날짜가 출퇴근 예외 조회에서 근무일로 반영되지 않고 `NO_SCHEDULE`로 처리될 수 있음.
+또한 본인 날짜별 일정 조회 API만 있어 팀원/관리자 화면에서 다른 사람의 날짜별 일정이 보이지 않음.
+
+**원인**
+`AttendanceExceptionService`가 반복 일정(`WorkSchedule`)만 조회하고 날짜별 일정(`WorkScheduleEvent`)을 보지 않았음.
+`WorkScheduleEventService`에도 팀/전체 조회 유스케이스가 없었음.
+
+**해결**
+예외 판정 시 날짜별 일정을 반복 일정보다 우선 적용하도록 `WorkScheduleEventRepository`를 주입하고,
+팀/전체 날짜별 일정 조회 API를 추가함.

--- a/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/exception/AttendanceExceptionService.java
@@ -6,6 +6,8 @@ import com.yanus.attendance.attendance.domain.attendance.AttendanceRepository;
 import com.yanus.attendance.attendance.domain.attendance.AttendanceStatus;
 import com.yanus.attendance.attendance.domain.exception.*;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEventRepository;
 import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleRepository;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionListResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
@@ -33,6 +35,7 @@ public class AttendanceExceptionService {
     private final AttendanceExceptionRepository exceptionRepository;
     private final AttendanceRepository attendanceRepository;
     private final WorkScheduleRepository workScheduleRepository;
+    private final WorkScheduleEventRepository workScheduleEventRepository;
     private final MemberRepository memberRepository;
     private final AttendanceSettingService settingService;
     private final AttendanceExceptionJudge judge = new AttendanceExceptionJudge();
@@ -119,7 +122,7 @@ public class AttendanceExceptionService {
     }
 
     private AttendanceExceptionResponse toResponse(AttendanceException exception) {
-        WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
+        WorkScheduleWindow schedule = findSchedule(exception.getMember(), exception.getWorkDate());
         return AttendanceExceptionResponse.from(
                 exception,
                 startOf(schedule),
@@ -128,25 +131,25 @@ public class AttendanceExceptionService {
         );
     }
 
-    private LocalTime startOf(WorkSchedule schedule) {
+    private LocalTime startOf(WorkScheduleWindow schedule) {
         if (schedule == null) {
             return null;
         }
-        return schedule.getStartTime();
+        return schedule.startTime();
     }
 
-    private LocalTime endOf(WorkSchedule schedule) {
+    private LocalTime endOf(WorkScheduleWindow schedule) {
         if (schedule == null) {
             return null;
         }
-        return schedule.getEndTime();
+        return schedule.endTime();
     }
 
-    private boolean endsNextDayOf(WorkSchedule schedule) {
+    private boolean endsNextDayOf(WorkScheduleWindow schedule) {
         if (schedule == null) {
             return false;
         }
-        return schedule.isEndsNextDay();
+        return schedule.endsNextDay();
     }
 
     private AttendanceExceptionSummary buildSummary(
@@ -168,16 +171,24 @@ public class AttendanceExceptionService {
     }
 
     private void generateFor(Member member, LocalDate date) {
-        WorkSchedule schedule = findSchedule(member, date);
+        WorkScheduleWindow schedule = findSchedule(member, date);
         Attendance attendance = findAttendance(member, date);
         boolean thresholdPassed = isThresholdPassed(date, schedule);
-        List<AttendanceExceptionType> detected = judge.judge(schedule, attendance, thresholdPassed);
+        List<AttendanceExceptionType> detected = judge.judgeByScheduledStart(
+                startOf(schedule), attendance, thresholdPassed);
         detected.forEach(type -> saveIfAbsent(member, attendance, date, type));
     }
 
-    private WorkSchedule findSchedule(Member member, LocalDate date) {
+    private WorkScheduleWindow findSchedule(Member member, LocalDate date) {
+        WorkScheduleEvent event = workScheduleEventRepository
+                .findByMemberIdAndDate(member.getId(), date)
+                .orElse(null);
+        if (event != null) {
+            return WorkScheduleWindow.from(event);
+        }
         return workScheduleRepository
                 .findByMemberIdAndDayOfWeek(member.getId(), date.getDayOfWeek())
+                .map(WorkScheduleWindow::from)
                 .orElse(null);
     }
 
@@ -201,20 +212,20 @@ public class AttendanceExceptionService {
                 .isPresent();
     }
 
-    private boolean isThresholdPassed(LocalDate date, WorkSchedule schedule) {
+    private boolean isThresholdPassed(LocalDate date, WorkScheduleWindow schedule) {
         LocalDateTime now = LocalDateTime.now(KST);
         LocalDateTime deadline = deadlineOf(date, schedule);
         return !now.isBefore(deadline);
     }
 
-    private LocalDateTime deadlineOf(LocalDate date, WorkSchedule schedule) {
+    private LocalDateTime deadlineOf(LocalDate date, WorkScheduleWindow schedule) {
         if (schedule == null) {
             return date.atTime(settingService.getAutoCheckoutTimeValue());
         }
-        if (schedule.isEndsNextDay()) {
-            return date.plusDays(1).atTime(schedule.getEndTime());
+        if (schedule.endsNextDay()) {
+            return date.plusDays(1).atTime(schedule.endTime());
         }
-        return date.atTime(schedule.getEndTime());
+        return date.atTime(schedule.endTime());
     }
 
     private List<AttendanceException> filterExceptions(
@@ -271,31 +282,31 @@ public class AttendanceExceptionService {
 
     private Long autoCheckOut(AttendanceException exception, String actor) {
         Attendance attendance = exception.getAttendance();
-        WorkSchedule schedule = findSchedule(exception.getMember(), exception.getWorkDate());
+        WorkScheduleWindow schedule = findSchedule(exception.getMember(), exception.getWorkDate());
         closeAttendance(attendance, exception.getWorkDate(), schedule);
         exception.resolve(actor, LocalDateTime.now(KST), "자동 퇴근 처리");
         return attendance.getId();
     }
 
-    private void closeAttendance(Attendance attendance, LocalDate workDate, WorkSchedule schedule) {
+    private void closeAttendance(Attendance attendance, LocalDate workDate, WorkScheduleWindow schedule) {
         if (attendance.getStatus() != AttendanceStatus.WORKING) {
             return;
         }
         attendance.checkOut(resolveCheckOutTime(attendance, workDate, schedule));
     }
 
-    private LocalDateTime resolveCheckOutTime(Attendance attendance, LocalDate workDate, WorkSchedule schedule) {
+    private LocalDateTime resolveCheckOutTime(Attendance attendance, LocalDate workDate, WorkScheduleWindow schedule) {
         if (isOvernight(schedule)) {
-            return workDate.plusDays(1).atTime(schedule.getEndTime());
+            return workDate.plusDays(1).atTime(schedule.endTime());
         }
         return resolveDaytimeCheckOut(attendance, workDate);
     }
 
-    private boolean isOvernight(WorkSchedule schedule) {
+    private boolean isOvernight(WorkScheduleWindow schedule) {
         if (schedule == null) {
             return false;
         }
-        return schedule.isEndsNextDay();
+        return schedule.endsNextDay();
     }
 
     private LocalDateTime resolveDaytimeCheckOut(Attendance attendance, LocalDate workDate) {
@@ -305,5 +316,21 @@ public class AttendanceExceptionService {
             return candidate;
         }
         return workDate.atTime(23, 59, 59);
+    }
+
+    private record WorkScheduleWindow(
+            LocalTime startTime,
+            LocalTime endTime,
+            boolean endsNextDay
+    ) {
+        private static WorkScheduleWindow from(WorkSchedule schedule) {
+            return new WorkScheduleWindow(
+                    schedule.getStartTime(), schedule.getEndTime(), schedule.isEndsNextDay());
+        }
+
+        private static WorkScheduleWindow from(WorkScheduleEvent event) {
+            return new WorkScheduleWindow(
+                    event.getStartTime(), event.getEndTime(), event.isEndsNextDay());
+        }
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/application/workschedule/WorkScheduleEventService.java
+++ b/src/main/java/com/yanus/attendance/attendance/application/workschedule/WorkScheduleEventService.java
@@ -8,6 +8,7 @@ import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
+import com.yanus.attendance.member.domain.MemberRole;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,22 @@ public class WorkScheduleEventService {
     @Transactional(readOnly = true)
     public List<WorkScheduleEventResponse> getEvents(Long memberId, LocalDate startDate, LocalDate endDate) {
         return workScheduleEventRepository.findAllByMemberIdAndDateBetween(memberId, startDate, endDate)
+                .stream().map(WorkScheduleEventResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorkScheduleEventResponse> getTeamEvents(
+            Long actorId, Long teamId, LocalDate startDate, LocalDate endDate) {
+        Member actor = findMember(actorId);
+        validateTeamScheduleAccess(actor, teamId);
+        return workScheduleEventRepository.findAllByTeamIdAndDateBetween(teamId, startDate, endDate)
+                .stream().map(WorkScheduleEventResponse::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<WorkScheduleEventResponse> getAllEvents(Long actorId, LocalDate startDate, LocalDate endDate) {
+        validateAdmin(actorId);
+        return workScheduleEventRepository.findAllByDateBetween(startDate, endDate)
                 .stream().map(WorkScheduleEventResponse::from).toList();
     }
 
@@ -65,5 +82,22 @@ public class WorkScheduleEventService {
     private Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateAdmin(Long actorId) {
+        Member actor = findMember(actorId);
+        if (actor.getRole() != MemberRole.ADMIN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    private void validateTeamScheduleAccess(Member actor, Long teamId) {
+        if (actor.getRole() == MemberRole.ADMIN) {
+            return;
+        }
+        if (actor.getTeam().getId().equals(teamId)) {
+            return;
+        }
+        throw new BusinessException(ErrorCode.FORBIDDEN);
     }
 }

--- a/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/exception/AttendanceExceptionJudge.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.attendance.domain.exception;
 import com.yanus.attendance.attendance.domain.attendance.Attendance;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,9 +14,18 @@ public class AttendanceExceptionJudge {
             Attendance attendance,
             boolean missedCheckoutThresholdPassed
     ) {
+        LocalTime scheduledStart = schedule == null ? null : schedule.getStartTime();
+        return judgeByScheduledStart(scheduledStart, attendance, missedCheckoutThresholdPassed);
+    }
+
+    public List<AttendanceExceptionType> judgeByScheduledStart(
+            LocalTime scheduledStart,
+            Attendance attendance,
+            boolean missedCheckoutThresholdPassed
+    ) {
         List<AttendanceExceptionType> result = new ArrayList<>();
 
-        boolean hasSchedule = schedule != null;
+        boolean hasSchedule = scheduledStart != null;
         boolean hasAttendance = attendance != null;
 
         if (isMissedCheckIn(hasSchedule, hasAttendance)) {
@@ -26,7 +36,7 @@ public class AttendanceExceptionJudge {
             result.add(AttendanceExceptionType.NO_SCHEDULE);
         }
 
-        if (isLate(hasSchedule, hasAttendance, attendance, schedule)) {
+        if (isLate(hasSchedule, hasAttendance, attendance, scheduledStart)) {
             result.add(AttendanceExceptionType.LATE);
         }
 
@@ -46,11 +56,11 @@ public class AttendanceExceptionJudge {
     }
 
     private boolean isLate(boolean hasSchedule, boolean hasAttendance,
-                           Attendance attendance, WorkSchedule schedule) {
+                           Attendance attendance, LocalTime scheduledStartTime) {
         if (!hasSchedule || !hasAttendance) {
             return false;
         }
-        LocalDateTime scheduledStart = attendance.getWorkDate().atTime(schedule.getStartTime());
+        LocalDateTime scheduledStart = attendance.getWorkDate().atTime(scheduledStartTime);
         return attendance.getCheckInTime().isAfter(scheduledStart);
     }
 

--- a/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/domain/workschedule/WorkScheduleEventRepository.java
@@ -14,5 +14,9 @@ public interface WorkScheduleEventRepository {
 
     List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
 
+    List<WorkScheduleEvent> findAllByTeamIdAndDateBetween(Long teamId, LocalDate start, LocalDate end);
+
+    List<WorkScheduleEvent> findAllByDateBetween(LocalDate start, LocalDate end);
+
     void delete(WorkScheduleEvent event);
 }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/workschedule/JpaWorkScheduleEventRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/workschedule/JpaWorkScheduleEventRepository.java
@@ -31,6 +31,16 @@ public class JpaWorkScheduleEventRepository implements WorkScheduleEventReposito
     }
 
     @Override
+    public List<WorkScheduleEvent> findAllByTeamIdAndDateBetween(Long teamId, LocalDate start, LocalDate end) {
+        return repository.findAllByMember_Team_IdAndDateBetween(teamId, start, end);
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByDateBetween(LocalDate start, LocalDate end) {
+        return repository.findAllByDateBetween(start, end);
+    }
+
+    @Override
     public void delete(WorkScheduleEvent event) {
         repository.delete(event);
     }

--- a/src/main/java/com/yanus/attendance/attendance/infrastructure/workschedule/WorkScheduleEventSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/attendance/infrastructure/workschedule/WorkScheduleEventSpringDataRepository.java
@@ -11,5 +11,8 @@ public interface WorkScheduleEventSpringDataRepository extends JpaRepository<Wor
     Optional<WorkScheduleEvent> findByMemberIdAndDate(Long memberId, LocalDate date);
 
     List<WorkScheduleEvent> findAllByMemberIdAndDateBetween(Long memberId, LocalDate start, LocalDate end);
-}
 
+    List<WorkScheduleEvent> findAllByMember_Team_IdAndDateBetween(Long teamId, LocalDate start, LocalDate end);
+
+    List<WorkScheduleEvent> findAllByDateBetween(LocalDate start, LocalDate end);
+}

--- a/src/main/java/com/yanus/attendance/attendance/presentation/workschedule/WorkScheduleEventController.java
+++ b/src/main/java/com/yanus/attendance/attendance/presentation/workschedule/WorkScheduleEventController.java
@@ -45,6 +45,25 @@ public class WorkScheduleEventController {
         return ResponseEntity.ok(ApiResponse.success(workScheduleEventService.getEvents(memberId, startDate, endDate)));
     }
 
+    @GetMapping("/team/{teamId}")
+    public ResponseEntity<ApiResponse<List<WorkScheduleEventResponse>>> getTeamEvents(
+            @AuthenticationPrincipal Long actorId,
+            @PathVariable Long teamId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(
+                workScheduleEventService.getTeamEvents(actorId, teamId, startDate, endDate)));
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<ApiResponse<List<WorkScheduleEventResponse>>> getAllEvents(
+            @AuthenticationPrincipal Long actorId,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(ApiResponse.success(
+                workScheduleEventService.getAllEvents(actorId, startDate, endDate)));
+    }
+
     @PutMapping("/{eventId}")
     public ResponseEntity<ApiResponse<WorkScheduleEventResponse>> updateEvent(
             @AuthenticationPrincipal Long memberId,

--- a/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
+++ b/src/test/java/com/yanus/attendance/attendance/FakeWorkScheduleEventRepository.java
@@ -42,8 +42,22 @@ public class FakeWorkScheduleEventRepository implements WorkScheduleEventReposit
     }
 
     @Override
+    public List<WorkScheduleEvent> findAllByTeamIdAndDateBetween(Long teamId, LocalDate start, LocalDate end) {
+        return store.values().stream()
+                .filter(e -> e.getMember().getTeam().getId().equals(teamId))
+                .filter(e -> !e.getDate().isBefore(start) && !e.getDate().isAfter(end))
+                .toList();
+    }
+
+    @Override
+    public List<WorkScheduleEvent> findAllByDateBetween(LocalDate start, LocalDate end) {
+        return store.values().stream()
+                .filter(e -> !e.getDate().isBefore(start) && !e.getDate().isAfter(end))
+                .toList();
+    }
+
+    @Override
     public void delete(WorkScheduleEvent event) {
         store.remove(event.getId());
     }
 }
-

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.yanus.attendance.attendance.FakeAttendanceExceptionRepository;
 import com.yanus.attendance.attendance.FakeAttendanceRepository;
 import com.yanus.attendance.attendance.FakeAttendanceSettingRepository;
+import com.yanus.attendance.attendance.FakeWorkScheduleEventRepository;
 import com.yanus.attendance.attendance.FakeWorkScheduleRepository;
 import com.yanus.attendance.attendance.application.exception.AttendanceExceptionService;
 import com.yanus.attendance.attendance.application.setting.AttendanceSettingService;
@@ -16,6 +17,7 @@ import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionStatu
 import com.yanus.attendance.attendance.domain.exception.AttendanceExceptionType;
 import com.yanus.attendance.attendance.domain.workschedule.WeekPattern;
 import com.yanus.attendance.attendance.domain.workschedule.WorkSchedule;
+import com.yanus.attendance.attendance.domain.workschedule.WorkScheduleEvent;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionListResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionResponse;
 import com.yanus.attendance.attendance.presentation.dto.exception.AttendanceExceptionSummary;
@@ -44,6 +46,7 @@ public class AttendanceExceptionServiceTest {
     private FakeAttendanceExceptionRepository exceptionRepository;
     private FakeAttendanceRepository attendanceRepository;
     private FakeWorkScheduleRepository workScheduleRepository;
+    private FakeWorkScheduleEventRepository workScheduleEventRepository;
     private FakeMemberRepository memberRepository;
     private FakeAttendanceSettingRepository settingRepository;
     private AttendanceSettingService settingService;
@@ -53,6 +56,7 @@ public class AttendanceExceptionServiceTest {
         exceptionRepository = new FakeAttendanceExceptionRepository();
         attendanceRepository = new FakeAttendanceRepository();
         workScheduleRepository = new FakeWorkScheduleRepository();
+        workScheduleEventRepository = new FakeWorkScheduleEventRepository();
         memberRepository = new FakeMemberRepository();
         settingRepository = new FakeAttendanceSettingRepository();
         settingService = new AttendanceSettingService(settingRepository, memberRepository);
@@ -61,6 +65,7 @@ public class AttendanceExceptionServiceTest {
                 exceptionRepository,
                 attendanceRepository,
                 workScheduleRepository,
+                workScheduleEventRepository,
                 memberRepository,
                 settingService
         );
@@ -205,6 +210,41 @@ public class AttendanceExceptionServiceTest {
         // when & then
         assertThatThrownBy(() -> service.approve(999L, "admin", null))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("날짜별 일정이 있으면 반복 일정이 없어도 NO_SCHEDULE로 판단하지 않는다")
+    void 날짜별_일정이_있으면_반복_일정이_없어도_NO_SCHEDULE로_판단하지_않는다() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleEventRepository.save(WorkScheduleEvent.create(
+                member, MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), false));
+        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0)));
+
+        // when
+        service.getExceptions(MONDAY, null, null, null);
+
+        // then
+        assertThat(exceptionRepository.findAllByWorkDate(MONDAY)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("날짜별 일정의 예외 응답은 날짜별 시작/종료 시간을 포함한다")
+    void 날짜별_일정의_예외_응답은_날짜별_시작_종료_시간을_포함한다() {
+        // given
+        Member member = createMember("홍길동", "hong@test.com");
+        workScheduleEventRepository.save(WorkScheduleEvent.create(
+                member, MONDAY, LocalTime.of(10, 0), LocalTime.of(19, 0), false));
+
+        // when
+        AttendanceExceptionListResponse response = service.getList(MONDAY, null, null, null);
+
+        // then
+        AttendanceExceptionResponse item = response.items().get(0);
+        assertThat(item.scheduledStartTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(item.scheduledEndTime()).isEqualTo(LocalTime.of(19, 0));
+        assertThat(item.scheduledStartAt()).isEqualTo(LocalDateTime.of(2026, 4, 20, 10, 0));
+        assertThat(item.scheduledEndAt()).isEqualTo(LocalDateTime.of(2026, 4, 20, 19, 0));
     }
 
     @Test

--- a/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/AttendanceExceptionServiceTest.java
@@ -219,13 +219,16 @@ public class AttendanceExceptionServiceTest {
         Member member = createMember("홍길동", "hong@test.com");
         workScheduleEventRepository.save(WorkScheduleEvent.create(
                 member, MONDAY, LocalTime.of(9, 0), LocalTime.of(18, 0), false));
-        attendanceRepository.save(Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0)));
+        Attendance attendance = Attendance.checkIn(member, LocalDateTime.of(2026, 4, 20, 9, 0));
+        attendance.checkOut(LocalDateTime.of(2026, 4, 20, 18, 0));
+        attendanceRepository.save(attendance);
 
         // when
         service.getExceptions(MONDAY, null, null, null);
 
         // then
-        assertThat(exceptionRepository.findAllByWorkDate(MONDAY)).isEmpty();
+        assertThat(exceptionRepository.findAllByWorkDate(MONDAY))
+                .noneMatch(exception -> exception.getType() == AttendanceExceptionType.NO_SCHEDULE);
     }
 
     @Test

--- a/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
+++ b/src/test/java/com/yanus/attendance/attendance/application/WorkScheduleEventServiceTest.java
@@ -27,17 +27,26 @@ public class WorkScheduleEventServiceTest {
 
     private WorkScheduleEventService workScheduleEventService;
     private MemberRepository memberRepository;
+    private FakeWorkScheduleEventRepository workScheduleEventRepository;
 
     @BeforeEach
     void setUp() {
         memberRepository = new FakeMemberRepository();
-        workScheduleEventService = new WorkScheduleEventService(new FakeWorkScheduleEventRepository(), memberRepository);
+        workScheduleEventRepository = new FakeWorkScheduleEventRepository();
+        workScheduleEventService = new WorkScheduleEventService(workScheduleEventRepository, memberRepository);
     }
 
     private Member createMember() {
         Team team = Team.create("1팀");
         ReflectionTestUtils.setField(team, "id", 1L);
         Member member = Member.create("테스터", "test@test.com", "password", MemberRole.MEMBER, MemberStatus.ACTIVE, team);
+        return memberRepository.save(member);
+    }
+
+    private Member createMember(String name, String email, MemberRole role, Long teamId, String teamName) {
+        Team team = Team.create(teamName);
+        ReflectionTestUtils.setField(team, "id", teamId);
+        Member member = Member.create(name, email, "password", role, MemberStatus.ACTIVE, team);
         return memberRepository.save(member);
     }
 
@@ -122,6 +131,57 @@ public class WorkScheduleEventServiceTest {
         List<WorkScheduleEventResponse> responses = workScheduleEventService.getEvents(
                 member.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
         assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("팀장은 같은 팀원의 날짜별 근무 일정을 조회할 수 있다")
+    void team_lead_can_get_team_events() {
+        // given
+        Member teamLead = createMember("팀장", "lead@test.com", MemberRole.TEAM_LEAD, 1L, "1팀");
+        Member member = createMember("팀원", "member@test.com", MemberRole.MEMBER, 1L, "1팀");
+        workScheduleEventService.createEvent(member.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 10), LocalTime.of(9, 0), LocalTime.of(18, 0), false));
+
+        // when
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getTeamEvents(
+                teamLead.getId(), 1L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("관리자는 전체 날짜별 근무 일정을 조회할 수 있다")
+    void admin_can_get_all_events() {
+        // given
+        Member admin = createMember("관리자", "admin@test.com", MemberRole.ADMIN, 1L, "1팀");
+        Member member1 = createMember("팀원1", "member1@test.com", MemberRole.MEMBER, 1L, "1팀");
+        Member member2 = createMember("팀원2", "member2@test.com", MemberRole.MEMBER, 2L, "2팀");
+        workScheduleEventService.createEvent(member1.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 10), LocalTime.of(9, 0), LocalTime.of(18, 0), false));
+        workScheduleEventService.createEvent(member2.getId(),
+                new WorkScheduleEventRequest(LocalDate.of(2026, 3, 20), LocalTime.of(10, 0), LocalTime.of(19, 0), false));
+
+        // when
+        List<WorkScheduleEventResponse> responses = workScheduleEventService.getAllEvents(
+                admin.getId(), LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31));
+
+        // then
+        assertThat(responses).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("일반 회원은 다른 팀 날짜별 근무 일정을 조회할 수 없다")
+    void member_cannot_get_other_team_events() {
+        // given
+        Member member = createMember("팀원", "member@test.com", MemberRole.MEMBER, 1L, "1팀");
+
+        // when & then
+        assertThatThrownBy(() -> workScheduleEventService.getTeamEvents(
+                member.getId(), 2L, LocalDate.of(2026, 3, 1), LocalDate.of(2026, 3, 31)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
closes #191

## 작업 내용
- 날짜별 근무 일정(`WorkScheduleEvent`)이 출퇴근 예외 판정에서 반복 일정(`WorkSchedule`)보다 우선 적용되도록 수정
- 반복 일정이 없어도 날짜별 일정이 있으면 `NO_SCHEDULE`로 판단하지 않도록 보강
- 예외 응답의 scheduled time/datetime에 날짜별 일정의 시작/종료 시간이 반영되도록 수정
- 날짜별 근무 일정 팀/전체 조회 API 추가
  - `GET /api/v1/work-schedule-events/team/{teamId}`
  - `GET /api/v1/work-schedule-events/all`
- 기존 반복 근무 일정 조회와 동일한 권한 규칙 적용
- `docs/troubleshooting.md`, `docs/troubleshooting/work-schedule.md`에 원인/해결 기록

## 원인
- `AttendanceExceptionService`가 반복 일정만 조회하고 날짜별 일정은 조회하지 않아, 날짜별 일정만 있는 날이 휴무처럼 처리될 수 있었음
- 날짜별 일정 조회 API가 본인 일정만 반환해 팀원/관리자 화면에서 다른 사람의 날짜별 일정을 가져갈 수 없었음

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 트러블슈팅 문서 기록
- [x] 대상 테스트 통과
- [ ] 전체 테스트 통과 — `AttendanceApplicationTests.contextLoads()`에서 Testcontainers/Docker 클라이언트 초기화 실패로 1건 실패

## 검증
- [x] `./gradlew test --tests "com.yanus.attendance.attendance.application.AttendanceExceptionServiceTest" --tests "com.yanus.attendance.attendance.application.WorkScheduleEventServiceTest"`
- [ ] `./gradlew test` — 237 tests 중 236 passed, 1 failed (`AttendanceApplicationTests.contextLoads`, Docker/Testcontainers 환경 문제)

## 프론트 영향
- 팀/관리자 화면에서 날짜별 일정을 보여줄 때 신규 조회 API를 사용할 수 있음
- 기존 본인 날짜별 일정 API는 유지됨