### PR TITLE
#49 #50 #51 #52 #53 - 채팅 채널 메시지 기능 구현 (목록 조회·텍스트/파일 전송·기본 채널 시딩)

### DIFF
--- a/src/main/java/com/yanus/attendance/chat/application/ChannelSeeder.java
+++ b/src/main/java/com/yanus/attendance/chat/application/ChannelSeeder.java
@@ -1,0 +1,55 @@
+package com.yanus.attendance.chat.application;
+
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelMember;
+import com.yanus.attendance.chat.domain.ChannelMemberRepository;
+import com.yanus.attendance.chat.domain.ChannelRepository;
+import com.yanus.attendance.chat.domain.ChannelType;
+import com.yanus.attendance.member.domain.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 애플리케이션 기동 시 기본 채널(General + 팀별)을 멱등하게 생성하고,
+ * 모든 멤버를 General 채널에 참여시킨다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ChannelSeeder implements ApplicationRunner {
+
+    private static final String GENERAL_CHANNEL = "General";
+    private static final List<String> TEAM_CHANNELS = List.of("DEV", "DESIGN", "MARKETING", "PRODUCT");
+
+    private final ChannelRepository channelRepository;
+    private final ChannelMemberRepository channelMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        seed();
+    }
+
+    public void seed() {
+        Channel general = ensureChannel(GENERAL_CHANNEL, ChannelType.GENERAL);
+        TEAM_CHANNELS.forEach(name -> ensureChannel(name, ChannelType.TEAM));
+        joinAllMembersToGeneral(general);
+    }
+
+    private Channel ensureChannel(String name, ChannelType type) {
+        return channelRepository.findByName(name)
+                .orElseGet(() -> channelRepository.save(Channel.create(name, type)));
+    }
+
+    private void joinAllMembersToGeneral(Channel general) {
+        memberRepository.findAll().forEach(member -> {
+            if (!channelMemberRepository.existsByChannelIdAndMemberId(general.getId(), member.getId())) {
+                channelMemberRepository.save(ChannelMember.create(general, member));
+            }
+        });
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/application/ChannelService.java
+++ b/src/main/java/com/yanus/attendance/chat/application/ChannelService.java
@@ -1,0 +1,22 @@
+package com.yanus.attendance.chat.application;
+
+import com.yanus.attendance.chat.domain.ChannelRepository;
+import com.yanus.attendance.chat.presentation.dto.ChannelResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChannelService {
+
+    private final ChannelRepository channelRepository;
+
+    public List<ChannelResponse> findAll() {
+        return channelRepository.findAll().stream()
+                .map(ChannelResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/application/MessageService.java
+++ b/src/main/java/com/yanus/attendance/chat/application/MessageService.java
@@ -1,10 +1,15 @@
 package com.yanus.attendance.chat.application;
 
+import com.yanus.attendance.chat.domain.Channel;
 import com.yanus.attendance.chat.domain.ChannelRepository;
+import com.yanus.attendance.chat.domain.Message;
 import com.yanus.attendance.chat.domain.MessageRepository;
+import com.yanus.attendance.chat.domain.MessageType;
 import com.yanus.attendance.chat.presentation.dto.MessageResponse;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -18,17 +23,31 @@ public class MessageService {
 
     private final MessageRepository messageRepository;
     private final ChannelRepository channelRepository;
+    private final MemberRepository memberRepository;
 
     public List<MessageResponse> getMessages(Long channelId, Pageable pageable) {
-        validateChannelExists(channelId);
+        findChannel(channelId);
         return messageRepository.findByChannelId(channelId, pageable).stream()
                 .map(MessageResponse::from)
                 .toList();
     }
 
-    private void validateChannelExists(Long channelId) {
-        if (channelRepository.findById(channelId).isEmpty()) {
-            throw new BusinessException(ErrorCode.CHANNEL_NOT_FOUND);
-        }
+    @Transactional
+    public MessageResponse sendMessage(Long channelId, Long senderId, String content, MessageType type) {
+        Channel channel = findChannel(channelId);
+        Member sender = findMember(senderId);
+        MessageType resolvedType = type == null ? MessageType.TEXT : type;
+        Message message = Message.create(channel, sender, content, resolvedType);
+        return MessageResponse.from(messageRepository.save(message));
+    }
+
+    private Channel findChannel(Long channelId) {
+        return channelRepository.findById(channelId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHANNEL_NOT_FOUND));
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/yanus/attendance/chat/application/MessageService.java
+++ b/src/main/java/com/yanus/attendance/chat/application/MessageService.java
@@ -6,15 +6,19 @@ import com.yanus.attendance.chat.domain.Message;
 import com.yanus.attendance.chat.domain.MessageRepository;
 import com.yanus.attendance.chat.domain.MessageType;
 import com.yanus.attendance.chat.presentation.dto.MessageResponse;
+import com.yanus.attendance.drive.domain.StorageService;
 import com.yanus.attendance.global.exception.BusinessException;
 import com.yanus.attendance.global.exception.ErrorCode;
 import com.yanus.attendance.member.domain.Member;
 import com.yanus.attendance.member.domain.MemberRepository;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,10 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final ChannelRepository channelRepository;
     private final MemberRepository memberRepository;
+    private final StorageService storageService;
+
+    @Value("${minio.bucket}")
+    private String bucket;
 
     public List<MessageResponse> getMessages(Long channelId, Pageable pageable) {
         findChannel(channelId);
@@ -38,6 +46,22 @@ public class MessageService {
         Member sender = findMember(senderId);
         MessageType resolvedType = type == null ? MessageType.TEXT : type;
         Message message = Message.create(channel, sender, content, resolvedType);
+        return MessageResponse.from(messageRepository.save(message));
+    }
+
+    @Transactional
+    public MessageResponse sendFileMessage(Long channelId, Long senderId, String content, List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            throw new BusinessException(ErrorCode.MESSAGE_FILE_REQUIRED);
+        }
+        Channel channel = findChannel(channelId);
+        Member sender = findMember(senderId);
+        Message message = Message.create(channel, sender, content, MessageType.FILE);
+        for (MultipartFile file : files) {
+            String storedName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            storageService.upload(file, storedName);
+            message.addFile(file.getOriginalFilename(), storedName, bucket, file.getSize(), file.getContentType());
+        }
         return MessageResponse.from(messageRepository.save(message));
     }
 

--- a/src/main/java/com/yanus/attendance/chat/application/MessageService.java
+++ b/src/main/java/com/yanus/attendance/chat/application/MessageService.java
@@ -1,0 +1,34 @@
+package com.yanus.attendance.chat.application;
+
+import com.yanus.attendance.chat.domain.ChannelRepository;
+import com.yanus.attendance.chat.domain.MessageRepository;
+import com.yanus.attendance.chat.presentation.dto.MessageResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final ChannelRepository channelRepository;
+
+    public List<MessageResponse> getMessages(Long channelId, Pageable pageable) {
+        validateChannelExists(channelId);
+        return messageRepository.findByChannelId(channelId, pageable).stream()
+                .map(MessageResponse::from)
+                .toList();
+    }
+
+    private void validateChannelExists(Long channelId) {
+        if (channelRepository.findById(channelId).isEmpty()) {
+            throw new BusinessException(ErrorCode.CHANNEL_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/Channel.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/Channel.java
@@ -1,0 +1,44 @@
+package com.yanus.attendance.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channel")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Channel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "channel_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private ChannelType type;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static Channel create(String name, ChannelType type) {
+        Channel channel = new Channel();
+        channel.name = name;
+        channel.type = type;
+        channel.createdAt = LocalDateTime.now();
+        return channel;
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/ChannelMember.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/ChannelMember.java
@@ -1,0 +1,48 @@
+package com.yanus.attendance.chat.domain;
+
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channel_member", uniqueConstraints = @UniqueConstraint(columnNames = {"channel_id", "member_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "channel_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    public static ChannelMember create(Channel channel, Member member) {
+        ChannelMember channelMember = new ChannelMember();
+        channelMember.channel = channel;
+        channelMember.member = member;
+        channelMember.joinedAt = LocalDateTime.now();
+        return channelMember;
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/ChannelMemberRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/ChannelMemberRepository.java
@@ -1,0 +1,8 @@
+package com.yanus.attendance.chat.domain;
+
+public interface ChannelMemberRepository {
+
+    ChannelMember save(ChannelMember channelMember);
+
+    boolean existsByChannelIdAndMemberId(Long channelId, Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/ChannelRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/ChannelRepository.java
@@ -1,0 +1,13 @@
+package com.yanus.attendance.chat.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChannelRepository {
+
+    Channel save(Channel channel);
+
+    Optional<Channel> findById(Long id);
+
+    List<Channel> findAll();
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/ChannelRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/ChannelRepository.java
@@ -9,5 +9,7 @@ public interface ChannelRepository {
 
     Optional<Channel> findById(Long id);
 
+    Optional<Channel> findByName(String name);
+
     List<Channel> findAll();
 }

--- a/src/main/java/com/yanus/attendance/chat/domain/ChannelType.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/ChannelType.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.chat.domain;
+
+public enum ChannelType {
+    GENERAL, TEAM, DIRECT
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/Message.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/Message.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.chat.domain;
 
 import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,8 +12,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,6 +47,9 @@ public class Message {
     @Column(name = "type", nullable = false, length = 20)
     private MessageType type;
 
+    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MessageFile> files = new ArrayList<>();
+
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
@@ -54,5 +61,9 @@ public class Message {
         message.type = type;
         message.createdAt = LocalDateTime.now();
         return message;
+    }
+
+    public void addFile(String originalName, String storedName, String bucket, Long size, String contentType) {
+        files.add(MessageFile.create(this, originalName, storedName, bucket, size, contentType));
     }
 }

--- a/src/main/java/com/yanus/attendance/chat/domain/Message.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/Message.java
@@ -1,0 +1,58 @@
+package com.yanus.attendance.chat.domain;
+
+import com.yanus.attendance.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id", nullable = false)
+    private Channel channel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private MessageType type;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public static Message create(Channel channel, Member sender, String content, MessageType type) {
+        Message message = new Message();
+        message.channel = channel;
+        message.sender = sender;
+        message.content = content;
+        message.type = type;
+        message.createdAt = LocalDateTime.now();
+        return message;
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/MessageFile.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/MessageFile.java
@@ -1,0 +1,62 @@
+package com.yanus.attendance.chat.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "message_file")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MessageFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_file_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id", nullable = false)
+    private Message message;
+
+    @Column(name = "original_name", nullable = false)
+    private String originalName;
+
+    @Column(name = "stored_name", nullable = false)
+    private String storedName;
+
+    @Column(name = "bucket", nullable = false)
+    private String bucket;
+
+    @Column(name = "size", nullable = false)
+    private Long size;
+
+    @Column(name = "content_type")
+    private String contentType;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    static MessageFile create(Message message, String originalName, String storedName,
+                              String bucket, Long size, String contentType) {
+        MessageFile file = new MessageFile();
+        file.message = message;
+        file.originalName = originalName;
+        file.storedName = storedName;
+        file.bucket = bucket;
+        file.size = size;
+        file.contentType = contentType;
+        file.createdAt = LocalDateTime.now();
+        return file;
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/MessageRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/MessageRepository.java
@@ -1,0 +1,14 @@
+package com.yanus.attendance.chat.domain;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+
+public interface MessageRepository {
+
+    Message save(Message message);
+
+    Optional<Message> findById(Long id);
+
+    List<Message> findByChannelId(Long channelId, Pageable pageable);
+}

--- a/src/main/java/com/yanus/attendance/chat/domain/MessageType.java
+++ b/src/main/java/com/yanus/attendance/chat/domain/MessageType.java
@@ -1,0 +1,5 @@
+package com.yanus.attendance.chat.domain;
+
+public enum MessageType {
+    TEXT, FILE
+}

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelJpaRepository.java
@@ -27,10 +27,16 @@ public class ChannelJpaRepository implements ChannelRepository {
     }
 
     @Override
+    public Optional<Channel> findByName(String name) {
+        return port.findByName(name);
+    }
+
+    @Override
     public List<Channel> findAll() {
         return port.findAll();
     }
 }
 
 interface ChannelJpaRepositoryPort extends JpaRepository<Channel, Long> {
+    Optional<Channel> findByName(String name);
 }

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelJpaRepository.java
@@ -1,0 +1,36 @@
+package com.yanus.attendance.chat.infrastructure;
+
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ChannelJpaRepository implements ChannelRepository {
+
+    private final ChannelJpaRepositoryPort port;
+
+    public ChannelJpaRepository(ChannelJpaRepositoryPort port) {
+        this.port = port;
+    }
+
+    @Override
+    public Channel save(Channel channel) {
+        return port.save(channel);
+    }
+
+    @Override
+    public Optional<Channel> findById(Long id) {
+        return port.findById(id);
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        return port.findAll();
+    }
+}
+
+interface ChannelJpaRepositoryPort extends JpaRepository<Channel, Long> {
+}

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelMemberJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelMemberJpaRepository.java
@@ -1,0 +1,23 @@
+package com.yanus.attendance.chat.infrastructure;
+
+import com.yanus.attendance.chat.domain.ChannelMember;
+import com.yanus.attendance.chat.domain.ChannelMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ChannelMemberJpaRepository implements ChannelMemberRepository {
+
+    private final ChannelMemberSpringDataRepository repository;
+
+    @Override
+    public ChannelMember save(ChannelMember channelMember) {
+        return repository.save(channelMember);
+    }
+
+    @Override
+    public boolean existsByChannelIdAndMemberId(Long channelId, Long memberId) {
+        return repository.existsByChannelIdAndMemberId(channelId, memberId);
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelMemberSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/ChannelMemberSpringDataRepository.java
@@ -1,0 +1,8 @@
+package com.yanus.attendance.chat.infrastructure;
+
+import com.yanus.attendance.chat.domain.ChannelMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelMemberSpringDataRepository extends JpaRepository<ChannelMember, Long> {
+    boolean existsByChannelIdAndMemberId(Long channelId, Long memberId);
+}

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/MessageJpaRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/MessageJpaRepository.java
@@ -1,0 +1,31 @@
+package com.yanus.attendance.chat.infrastructure;
+
+import com.yanus.attendance.chat.domain.Message;
+import com.yanus.attendance.chat.domain.MessageRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageJpaRepository implements MessageRepository {
+
+    private final MessageSpringDataRepository repository;
+
+    @Override
+    public Message save(Message message) {
+        return repository.save(message);
+    }
+
+    @Override
+    public Optional<Message> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<Message> findByChannelId(Long channelId, Pageable pageable) {
+        return repository.findByChannelId(channelId, pageable);
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/infrastructure/MessageSpringDataRepository.java
+++ b/src/main/java/com/yanus/attendance/chat/infrastructure/MessageSpringDataRepository.java
@@ -1,0 +1,10 @@
+package com.yanus.attendance.chat.infrastructure;
+
+import com.yanus.attendance.chat.domain.Message;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageSpringDataRepository extends JpaRepository<Message, Long> {
+    List<Message> findByChannelId(Long channelId, Pageable pageable);
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/ChannelController.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/ChannelController.java
@@ -1,0 +1,26 @@
+package com.yanus.attendance.chat.presentation;
+
+import com.yanus.attendance.chat.application.ChannelService;
+import com.yanus.attendance.chat.presentation.dto.ChannelResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "채팅 채널", description = "채팅 채널 목록 조회")
+@RestController
+@RequestMapping("/api/v1/channels")
+@RequiredArgsConstructor
+public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChannelResponse>>> findAll() {
+        return ResponseEntity.ok(ApiResponse.success(channelService.findAll()));
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
@@ -1,0 +1,32 @@
+package com.yanus.attendance.chat.presentation;
+
+import com.yanus.attendance.chat.application.MessageService;
+import com.yanus.attendance.chat.presentation.dto.MessageResponse;
+import com.yanus.attendance.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "채팅 메시지", description = "채널 메시지 목록 조회")
+@RestController
+@RequestMapping("/api/v1/channels")
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @GetMapping("/{channelId}/messages")
+    public ResponseEntity<ApiResponse<List<MessageResponse>>> getMessages(
+            @PathVariable Long channelId,
+            @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(ApiResponse.success(messageService.getMessages(channelId, pageable)));
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
@@ -1,6 +1,7 @@
 package com.yanus.attendance.chat.presentation;
 
 import com.yanus.attendance.chat.application.MessageService;
+import com.yanus.attendance.chat.presentation.dto.MessageCreateRequest;
 import com.yanus.attendance.chat.presentation.dto.MessageResponse;
 import com.yanus.attendance.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,9 +10,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,5 +33,14 @@ public class MessageController {
             @PathVariable Long channelId,
             @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(ApiResponse.success(messageService.getMessages(channelId, pageable)));
+    }
+
+    @PostMapping("/{channelId}/messages")
+    public ResponseEntity<ApiResponse<MessageResponse>> sendMessage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long channelId,
+            @RequestBody MessageCreateRequest request) {
+        MessageResponse response = messageService.sendMessage(channelId, memberId, request.content(), request.type());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/MessageController.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +19,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "채팅 메시지", description = "채널 메시지 목록 조회")
 @RestController
@@ -41,6 +44,16 @@ public class MessageController {
             @PathVariable Long channelId,
             @RequestBody MessageCreateRequest request) {
         MessageResponse response = messageService.sendMessage(channelId, memberId, request.content(), request.type());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    @PostMapping(value = "/{channelId}/messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<MessageResponse>> sendFileMessage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long channelId,
+            @RequestParam(value = "content", required = false) String content,
+            @RequestParam("files") List<MultipartFile> files) {
+        MessageResponse response = messageService.sendFileMessage(channelId, memberId, content, files);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/yanus/attendance/chat/presentation/dto/ChannelResponse.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/dto/ChannelResponse.java
@@ -1,0 +1,14 @@
+package com.yanus.attendance.chat.presentation.dto;
+
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelType;
+
+public record ChannelResponse(
+        Long id,
+        String name,
+        ChannelType type
+) {
+    public static ChannelResponse from(Channel channel) {
+        return new ChannelResponse(channel.getId(), channel.getName(), channel.getType());
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageCreateRequest.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageCreateRequest.java
@@ -1,0 +1,9 @@
+package com.yanus.attendance.chat.presentation.dto;
+
+import com.yanus.attendance.chat.domain.MessageType;
+
+public record MessageCreateRequest(
+        String content,
+        MessageType type
+) {
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageFileResponse.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageFileResponse.java
@@ -1,0 +1,19 @@
+package com.yanus.attendance.chat.presentation.dto;
+
+import com.yanus.attendance.chat.domain.MessageFile;
+
+public record MessageFileResponse(
+        Long id,
+        String originalName,
+        Long size,
+        String contentType
+) {
+    public static MessageFileResponse from(MessageFile file) {
+        return new MessageFileResponse(
+                file.getId(),
+                file.getOriginalName(),
+                file.getSize(),
+                file.getContentType()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageResponse.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageResponse.java
@@ -1,0 +1,27 @@
+package com.yanus.attendance.chat.presentation.dto;
+
+import com.yanus.attendance.chat.domain.Message;
+import com.yanus.attendance.chat.domain.MessageType;
+import java.time.LocalDateTime;
+
+public record MessageResponse(
+        Long id,
+        Long channelId,
+        Long senderId,
+        String senderName,
+        String content,
+        MessageType type,
+        LocalDateTime createdAt
+) {
+    public static MessageResponse from(Message message) {
+        return new MessageResponse(
+                message.getId(),
+                message.getChannel().getId(),
+                message.getSender().getId(),
+                message.getSender().getName(),
+                message.getContent(),
+                message.getType(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageResponse.java
+++ b/src/main/java/com/yanus/attendance/chat/presentation/dto/MessageResponse.java
@@ -3,6 +3,7 @@ package com.yanus.attendance.chat.presentation.dto;
 import com.yanus.attendance.chat.domain.Message;
 import com.yanus.attendance.chat.domain.MessageType;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record MessageResponse(
         Long id,
@@ -11,6 +12,7 @@ public record MessageResponse(
         String senderName,
         String content,
         MessageType type,
+        List<MessageFileResponse> files,
         LocalDateTime createdAt
 ) {
     public static MessageResponse from(Message message) {
@@ -21,6 +23,7 @@ public record MessageResponse(
                 message.getSender().getName(),
                 message.getContent(),
                 message.getType(),
+                message.getFiles().stream().map(MessageFileResponse::from).toList(),
                 message.getCreatedAt()
         );
     }

--- a/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanus/attendance/global/exception/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
     DRIVE_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "DRIVE_FILE_NOT_FOUND", "파일을 찾을 수 없습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_UPLOAD_FAILED", "파일 업로드에 실패했습니다."),
 
+    // Chat
+    CHANNEL_NOT_FOUND(HttpStatus.NOT_FOUND, "CHANNEL_NOT_FOUND", "존재하지 않는 채널입니다."),
+    MESSAGE_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "MESSAGE_FILE_REQUIRED", "첨부 파일이 필요합니다."),
+
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/main/resources/db/migration/V24__create_channel.sql
+++ b/src/main/resources/db/migration/V24__create_channel.sql
@@ -1,0 +1,7 @@
+CREATE TABLE channel
+(
+    channel_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name       VARCHAR(100) NOT NULL,
+    type       VARCHAR(20)  NOT NULL,
+    created_at TIMESTAMP    NOT NULL
+);

--- a/src/main/resources/db/migration/V25__create_message.sql
+++ b/src/main/resources/db/migration/V25__create_message.sql
@@ -1,0 +1,11 @@
+CREATE TABLE message
+(
+    message_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    channel_id BIGINT      NOT NULL REFERENCES channel (channel_id),
+    sender_id  BIGINT      NOT NULL REFERENCES member (member_id),
+    content    TEXT,
+    type       VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP   NOT NULL
+);
+
+CREATE INDEX idx_message_channel_created_at ON message (channel_id, created_at DESC);

--- a/src/main/resources/db/migration/V26__create_message_file.sql
+++ b/src/main/resources/db/migration/V26__create_message_file.sql
@@ -1,0 +1,13 @@
+CREATE TABLE message_file
+(
+    message_file_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    message_id      BIGINT       NOT NULL REFERENCES message (message_id),
+    original_name   VARCHAR(255) NOT NULL,
+    stored_name     VARCHAR(255) NOT NULL,
+    bucket          VARCHAR(100) NOT NULL,
+    size            BIGINT       NOT NULL,
+    content_type    VARCHAR(100),
+    created_at      TIMESTAMP    NOT NULL
+);
+
+CREATE INDEX idx_message_file_message ON message_file (message_id);

--- a/src/main/resources/db/migration/V27__create_channel_member.sql
+++ b/src/main/resources/db/migration/V27__create_channel_member.sql
@@ -1,0 +1,10 @@
+CREATE TABLE channel_member
+(
+    channel_member_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    channel_id        BIGINT    NOT NULL REFERENCES channel (channel_id),
+    member_id         BIGINT    NOT NULL REFERENCES member (member_id),
+    joined_at         TIMESTAMP NOT NULL,
+    CONSTRAINT uq_channel_member UNIQUE (channel_id, member_id)
+);
+
+CREATE INDEX idx_channel_member_member ON channel_member (member_id);

--- a/src/test/java/com/yanus/attendance/chat/FakeChannelMemberRepository.java
+++ b/src/test/java/com/yanus/attendance/chat/FakeChannelMemberRepository.java
@@ -1,0 +1,30 @@
+package com.yanus.attendance.chat;
+
+import com.yanus.attendance.chat.domain.ChannelMember;
+import com.yanus.attendance.chat.domain.ChannelMemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeChannelMemberRepository implements ChannelMemberRepository {
+
+    private final List<ChannelMember> store = new ArrayList<>();
+    private Long sequence = 1L;
+
+    @Override
+    public ChannelMember save(ChannelMember channelMember) {
+        ReflectionTestUtils.setField(channelMember, "id", sequence++);
+        store.add(channelMember);
+        return channelMember;
+    }
+
+    @Override
+    public boolean existsByChannelIdAndMemberId(Long channelId, Long memberId) {
+        return store.stream().anyMatch(cm ->
+                cm.getChannel().getId().equals(channelId) && cm.getMember().getId().equals(memberId));
+    }
+
+    public int size() {
+        return store.size();
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/FakeChannelRepository.java
+++ b/src/test/java/com/yanus/attendance/chat/FakeChannelRepository.java
@@ -27,6 +27,13 @@ public class FakeChannelRepository implements ChannelRepository {
     }
 
     @Override
+    public Optional<Channel> findByName(String name) {
+        return store.values().stream()
+                .filter(channel -> channel.getName().equals(name))
+                .findFirst();
+    }
+
+    @Override
     public List<Channel> findAll() {
         return new ArrayList<>(store.values());
     }

--- a/src/test/java/com/yanus/attendance/chat/FakeChannelRepository.java
+++ b/src/test/java/com/yanus/attendance/chat/FakeChannelRepository.java
@@ -1,0 +1,33 @@
+package com.yanus.attendance.chat;
+
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeChannelRepository implements ChannelRepository {
+
+    private final Map<Long, Channel> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public Channel save(Channel channel) {
+        ReflectionTestUtils.setField(channel, "id", sequence++);
+        store.put(channel.getId(), channel);
+        return channel;
+    }
+
+    @Override
+    public Optional<Channel> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<Channel> findAll() {
+        return new ArrayList<>(store.values());
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/FakeMessageRepository.java
+++ b/src/test/java/com/yanus/attendance/chat/FakeMessageRepository.java
@@ -1,0 +1,48 @@
+package com.yanus.attendance.chat;
+
+import com.yanus.attendance.chat.domain.Message;
+import com.yanus.attendance.chat.domain.MessageRepository;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FakeMessageRepository implements MessageRepository {
+
+    private final Map<Long, Message> store = new HashMap<>();
+    private Long sequence = 1L;
+
+    @Override
+    public Message save(Message message) {
+        if (message.getId() == null) {
+            ReflectionTestUtils.setField(message, "id", sequence++);
+        }
+        store.put(message.getId(), message);
+        return message;
+    }
+
+    @Override
+    public Optional<Message> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<Message> findByChannelId(Long channelId, Pageable pageable) {
+        Comparator<Message> byCreatedAt = Comparator.comparing(Message::getCreatedAt)
+                .thenComparing(Message::getId);
+        Sort.Order order = pageable.getSort().getOrderFor("createdAt");
+        if (order == null || order.isDescending()) {
+            byCreatedAt = byCreatedAt.reversed();
+        }
+        return store.values().stream()
+                .filter(m -> m.getChannel().getId().equals(channelId))
+                .sorted(byCreatedAt)
+                .skip(pageable.isPaged() ? pageable.getOffset() : 0)
+                .limit(pageable.isPaged() ? pageable.getPageSize() : Long.MAX_VALUE)
+                .toList();
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/FakeStorageService.java
+++ b/src/test/java/com/yanus/attendance/chat/FakeStorageService.java
@@ -1,0 +1,31 @@
+package com.yanus.attendance.chat;
+
+import com.yanus.attendance.drive.domain.StorageService;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public class FakeStorageService implements StorageService {
+
+    private final List<String> uploaded = new ArrayList<>();
+
+    @Override
+    public String upload(MultipartFile file, String storedName) {
+        uploaded.add(storedName);
+        return storedName;
+    }
+
+    @Override
+    public byte[] download(String fileName) {
+        return new byte[0];
+    }
+
+    @Override
+    public void delete(String fileName) {
+        uploaded.remove(fileName);
+    }
+
+    public int uploadCount() {
+        return uploaded.size();
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/application/ChannelSeederTest.java
+++ b/src/test/java/com/yanus/attendance/chat/application/ChannelSeederTest.java
@@ -1,0 +1,76 @@
+package com.yanus.attendance.chat.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.chat.FakeChannelMemberRepository;
+import com.yanus.attendance.chat.FakeChannelRepository;
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelType;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.FakeTeamRepository;
+import com.yanus.attendance.team.domain.Team;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ChannelSeederTest {
+
+    private ChannelSeeder channelSeeder;
+    private FakeChannelRepository channelRepository;
+    private FakeChannelMemberRepository channelMemberRepository;
+    private FakeMemberRepository memberRepository;
+    private FakeTeamRepository teamRepository;
+
+    @BeforeEach
+    void setUp() {
+        channelRepository = new FakeChannelRepository();
+        channelMemberRepository = new FakeChannelMemberRepository();
+        memberRepository = new FakeMemberRepository();
+        teamRepository = new FakeTeamRepository();
+        channelSeeder = new ChannelSeeder(channelRepository, channelMemberRepository, memberRepository);
+    }
+
+    @Test
+    @DisplayName("기본 채널 5개(General + 팀별 4개)를 생성한다")
+    void seeds_default_channels() {
+        // when
+        channelSeeder.seed();
+
+        // then
+        List<Channel> channels = channelRepository.findAll();
+        assertThat(channels).hasSize(5);
+        assertThat(channels).anyMatch(c -> c.getName().equals("General") && c.getType() == ChannelType.GENERAL);
+        assertThat(channels).filteredOn(c -> c.getType() == ChannelType.TEAM).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("두 번 실행해도 채널이 중복 생성되지 않는다")
+    void seeding_is_idempotent() {
+        // when
+        channelSeeder.seed();
+        channelSeeder.seed();
+
+        // then
+        assertThat(channelRepository.findAll()).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("모든 멤버를 General 채널에 참여시킨다")
+    void joins_all_members_to_general() {
+        // given
+        Team team = teamRepository.save(Team.create("기본팀"));
+        memberRepository.save(Member.create("A", "a@yanus.com", "enc", MemberRole.MEMBER, MemberStatus.ACTIVE, team));
+        memberRepository.save(Member.create("B", "b@yanus.com", "enc", MemberRole.MEMBER, MemberStatus.ACTIVE, team));
+
+        // when
+        channelSeeder.seed();
+        channelSeeder.seed();
+
+        // then
+        assertThat(channelMemberRepository.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/application/ChannelServiceTest.java
+++ b/src/test/java/com/yanus/attendance/chat/application/ChannelServiceTest.java
@@ -1,0 +1,62 @@
+package com.yanus.attendance.chat.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yanus.attendance.chat.FakeChannelRepository;
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelType;
+import com.yanus.attendance.chat.presentation.dto.ChannelResponse;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ChannelServiceTest {
+
+    private ChannelService channelService;
+    private FakeChannelRepository channelRepository;
+
+    @BeforeEach
+    void setUp() {
+        channelRepository = new FakeChannelRepository();
+        channelService = new ChannelService(channelRepository);
+    }
+
+    @Test
+    @DisplayName("전체 채널 목록 조회")
+    void find_all() {
+        // given
+        channelRepository.save(Channel.create("General", ChannelType.GENERAL));
+        channelRepository.save(Channel.create("개발팀", ChannelType.TEAM));
+
+        // when
+        List<ChannelResponse> result = channelService.findAll();
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("채널이 없으면 빈 목록을 반환")
+    void find_all_empty() {
+        // when
+        List<ChannelResponse> result = channelService.findAll();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조회 결과에 채널 이름과 타입이 매핑된다")
+    void find_all_maps_fields() {
+        // given
+        channelRepository.save(Channel.create("General", ChannelType.GENERAL));
+
+        // when
+        ChannelResponse result = channelService.findAll().get(0);
+
+        // then
+        assertThat(result.name()).isEqualTo("General");
+        assertThat(result.type()).isEqualTo(ChannelType.GENERAL);
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
+++ b/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
@@ -1,0 +1,110 @@
+package com.yanus.attendance.chat.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yanus.attendance.chat.FakeChannelRepository;
+import com.yanus.attendance.chat.FakeMessageRepository;
+import com.yanus.attendance.chat.domain.Channel;
+import com.yanus.attendance.chat.domain.ChannelType;
+import com.yanus.attendance.chat.domain.Message;
+import com.yanus.attendance.chat.domain.MessageType;
+import com.yanus.attendance.chat.presentation.dto.MessageResponse;
+import com.yanus.attendance.global.exception.BusinessException;
+import com.yanus.attendance.global.exception.ErrorCode;
+import com.yanus.attendance.member.FakeMemberRepository;
+import com.yanus.attendance.member.domain.Member;
+import com.yanus.attendance.member.domain.MemberRole;
+import com.yanus.attendance.member.domain.MemberStatus;
+import com.yanus.attendance.team.FakeTeamRepository;
+import com.yanus.attendance.team.domain.Team;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+public class MessageServiceTest {
+
+    private MessageService messageService;
+    private FakeMessageRepository messageRepository;
+    private FakeChannelRepository channelRepository;
+    private FakeMemberRepository memberRepository;
+    private FakeTeamRepository teamRepository;
+
+    private Channel channel;
+    private Member sender;
+
+    @BeforeEach
+    void setUp() {
+        messageRepository = new FakeMessageRepository();
+        channelRepository = new FakeChannelRepository();
+        memberRepository = new FakeMemberRepository();
+        teamRepository = new FakeTeamRepository();
+        messageService = new MessageService(messageRepository, channelRepository);
+
+        channel = channelRepository.save(Channel.create("General", ChannelType.GENERAL));
+        Team team = teamRepository.save(Team.create("기본팀"));
+        sender = memberRepository.save(
+                Member.create("보낸이", "sender@yanus.com", "encoded", MemberRole.MEMBER, MemberStatus.ACTIVE, team));
+    }
+
+    private PageRequest latestFirst(int size) {
+        return PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    }
+
+    @Test
+    @DisplayName("채널 메시지 목록을 조회한다")
+    void get_messages() {
+        // given
+        messageRepository.save(Message.create(channel, sender, "첫 메시지", MessageType.TEXT));
+        messageRepository.save(Message.create(channel, sender, "둘째 메시지", MessageType.TEXT));
+
+        // when
+        List<MessageResponse> result = messageService.getMessages(channel.getId(), latestFirst(50));
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).senderName()).isEqualTo("보낸이");
+        assertThat(result.get(0).channelId()).isEqualTo(channel.getId());
+    }
+
+    @Test
+    @DisplayName("페이지 크기만큼만 반환한다")
+    void get_messages_paged() {
+        // given
+        for (int i = 0; i < 5; i++) {
+            messageRepository.save(Message.create(channel, sender, "메시지 " + i, MessageType.TEXT));
+        }
+
+        // when
+        List<MessageResponse> result = messageService.getMessages(channel.getId(), latestFirst(2));
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("최신 메시지가 먼저 정렬된다")
+    void get_messages_latest_first() {
+        // given
+        messageRepository.save(Message.create(channel, sender, "오래된 메시지", MessageType.TEXT));
+        Message latest = messageRepository.save(Message.create(channel, sender, "최신 메시지", MessageType.TEXT));
+
+        // when
+        List<MessageResponse> result = messageService.getMessages(channel.getId(), latestFirst(50));
+
+        // then
+        assertThat(result.get(0).id()).isEqualTo(latest.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채널 조회 시 예외 발생")
+    void get_messages_channel_not_found() {
+        // when & then
+        assertThatThrownBy(() -> messageService.getMessages(999L, latestFirst(50)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CHANNEL_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
+++ b/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
@@ -42,7 +42,7 @@ public class MessageServiceTest {
         channelRepository = new FakeChannelRepository();
         memberRepository = new FakeMemberRepository();
         teamRepository = new FakeTeamRepository();
-        messageService = new MessageService(messageRepository, channelRepository);
+        messageService = new MessageService(messageRepository, channelRepository, memberRepository);
 
         channel = channelRepository.save(Channel.create("General", ChannelType.GENERAL));
         Team team = teamRepository.save(Team.create("기본팀"));
@@ -106,5 +106,48 @@ public class MessageServiceTest {
         assertThatThrownBy(() -> messageService.getMessages(999L, latestFirst(50)))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CHANNEL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("텍스트 메시지를 전송한다")
+    void send_text_message() {
+        // when
+        MessageResponse result = messageService.sendMessage(
+                channel.getId(), sender.getId(), "안녕하세요", MessageType.TEXT);
+
+        // then
+        assertThat(result.content()).isEqualTo("안녕하세요");
+        assertThat(result.type()).isEqualTo(MessageType.TEXT);
+        assertThat(result.senderId()).isEqualTo(sender.getId());
+        assertThat(messageService.getMessages(channel.getId(), latestFirst(50))).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("type이 없으면 TEXT로 저장된다")
+    void send_message_defaults_to_text() {
+        // when
+        MessageResponse result = messageService.sendMessage(
+                channel.getId(), sender.getId(), "타입 미지정", null);
+
+        // then
+        assertThat(result.type()).isEqualTo(MessageType.TEXT);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 채널에 전송 시 예외 발생")
+    void send_message_channel_not_found() {
+        // when & then
+        assertThatThrownBy(() -> messageService.sendMessage(999L, sender.getId(), "안녕", MessageType.TEXT))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CHANNEL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버가 전송 시 예외 발생")
+    void send_message_member_not_found() {
+        // when & then
+        assertThatThrownBy(() -> messageService.sendMessage(channel.getId(), 999L, "안녕", MessageType.TEXT))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
+++ b/src/test/java/com/yanus/attendance/chat/application/MessageServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.yanus.attendance.chat.FakeChannelRepository;
 import com.yanus.attendance.chat.FakeMessageRepository;
+import com.yanus.attendance.chat.FakeStorageService;
 import com.yanus.attendance.chat.domain.Channel;
 import com.yanus.attendance.chat.domain.ChannelType;
 import com.yanus.attendance.chat.domain.Message;
@@ -24,6 +25,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 public class MessageServiceTest {
 
@@ -32,6 +36,7 @@ public class MessageServiceTest {
     private FakeChannelRepository channelRepository;
     private FakeMemberRepository memberRepository;
     private FakeTeamRepository teamRepository;
+    private FakeStorageService storageService;
 
     private Channel channel;
     private Member sender;
@@ -42,7 +47,9 @@ public class MessageServiceTest {
         channelRepository = new FakeChannelRepository();
         memberRepository = new FakeMemberRepository();
         teamRepository = new FakeTeamRepository();
-        messageService = new MessageService(messageRepository, channelRepository, memberRepository);
+        storageService = new FakeStorageService();
+        messageService = new MessageService(messageRepository, channelRepository, memberRepository, storageService);
+        ReflectionTestUtils.setField(messageService, "bucket", "test-bucket");
 
         channel = channelRepository.save(Channel.create("General", ChannelType.GENERAL));
         Team team = teamRepository.save(Team.create("기본팀"));
@@ -149,5 +156,32 @@ public class MessageServiceTest {
         assertThatThrownBy(() -> messageService.sendMessage(channel.getId(), 999L, "안녕", MessageType.TEXT))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("파일 첨부 메시지를 전송한다")
+    void send_file_message() {
+        // given
+        MultipartFile file = new MockMultipartFile(
+                "files", "report.pdf", "application/pdf", "dummy".getBytes());
+
+        // when
+        MessageResponse result = messageService.sendFileMessage(
+                channel.getId(), sender.getId(), "파일 첨부", List.of(file));
+
+        // then
+        assertThat(result.type()).isEqualTo(MessageType.FILE);
+        assertThat(result.files()).hasSize(1);
+        assertThat(result.files().get(0).originalName()).isEqualTo("report.pdf");
+        assertThat(storageService.uploadCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("첨부 파일이 없으면 예외 발생")
+    void send_file_message_no_file() {
+        // when & then
+        assertThatThrownBy(() -> messageService.sendFileMessage(channel.getId(), sender.getId(), "내용", List.of()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MESSAGE_FILE_REQUIRED);
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #49 #50 #51 #52 #53 

## 작업 내용
- 채팅 채널 메시지 도메인(Message)·인프라·서비스·API 추가 (#49 채널 목록 조회 위에 이어짐)
- Message 엔티티 추가 — channel/sender FK, content(TEXT), MessageType(TEXT/FILE), createdAt
- MessageRepository(페이징) 도메인 인터페이스 + Spring Data/JPA 어댑터(포트-어댑터)
- 메시지 목록 조회 GET /api/v1/channels/{channelId}/messages?page=0&size=50
- 최신순(createdAt DESC) 기본 정렬, MessageResponse[] 반환
- 채널 미존재 시 CHANNEL_NOT_FOUND
- 텍스트 메시지 전송 POST /api/v1/channels/{channelId}/messages (201 Created)
- MessageCreateRequest(content, type), sender = 현재 멤버(@AuthenticationPrincipal)
- type 미지정 시 TEXT로 저장
- 파일 첨부 메시지 전송 — 같은 경로를 multipart/form-data로 분기
- MessageFile 엔티티 + Message.files(@OneToMany, cascade) + addFile
- MultipartFile 업로드는 drive 모듈 StorageService(MinIO) 재사용, type=FILE 저장
- 첨부 없으면 MESSAGE_FILE_REQUIRED, MessageResponse에 files(MessageFileResponse[]) 포함
- 기본 채널 자동 생성 — ChannelSeeder(ApplicationRunner)
- 기동 시 General(GENERAL) + 팀별 4개(DEV/DESIGN/MARKETING/PRODUCT, TEAM) 멱등 생성
- 전체 멤버를 General 채널에 참여 (멱등)
- ChannelMember 엔티티 + 리포지토리, ChannelRepository.findByName 추가
- Flyway 마이그레이션 추가
- V25__create_message.sql (channel/sender FK, (channel_id, created_at) 인덱스)
- V26__create_message_file.sql (message FK, message_id 인덱스)
- V27__create_channel_member.sql (channel/member 유니크 제약)
- ErrorCode에 CHANNEL_NOT_FOUND, MESSAGE_FILE_REQUIRED 추가

## 체크리스트
- [x] 테스트 작성 (Red)
- [x] 기능 구현 (Green)
- [x] 리팩터링 완료
- [x] 테스트 전체 통과

## 정책 결정
- 마이그레이션 버전: 이슈에는 V10__create_channel.sql로 명시됐으나 V10이 이미 선점되어 채널 테이블(#49)은 V24, 메시지/파일/멤버는 V25~V27로 작성
- 메시지 응답은 페이지 메타데이터(totalElements 등) 없이 MessageResponse[]만 반환 — 이슈 명세 및 프론트 배열 계약에 맞춤
- 텍스트/파일 전송은 동일 엔드포인트를 content-type으로 분기(JSON vs multipart) — 프론트의 type 기반 호출과 호환
- 파일 저장은 신규 스토리지 추상화를 만들지 않고 drive 모듈의 MinIO StorageService 빈을 재사용
- 기본 채널 시딩은 별도 데이터 마이그레이션 대신 ApplicationRunner로 처리하고, findByName/existsByChannelIdAndMemberId로 멱등 보장

체크리스트
-  테스트 작성 (Red)
-  기능 구현 (Green)
-  DB 마이그레이션 추가
-  대상 테스트 통과
-  전체 테스트 통과

검증
-  ./gradlew test --tests "com.yanus.attendance.chat.*" — chat 모듈 단위 테스트(ChannelService/MessageService/ChannelSeeder) 통과
-  ./gradlew compileJava compileTestJava — 이슈 단계별 컴파일 통과
-  ./gradlew test — 전체 테스트 BUILD SUCCESSFUL (AttendanceApplicationTests.contextLoads() 포함, 신규 엔티티 4종 + ChannelSeeder 기동을 Testcontainers 스키마에서 검증)
- 프론트 영향
- 채널 목록: GET /api/v1/channels 응답에 type(GENERAL/TEAM/DIRECT) 포함
- 메시지 목록: GET /api/v1/channels/{channelId}/messages?page=0&size=50 — 최신순 배열, 각 항목에 senderId/senderName/content/type/files/createdAt
- 텍스트 전송: POST .../messages JSON 바디 { "content": "...", "type": "TEXT" }
- 파일 전송: 같은 경로에 multipart/form-data로 content(선택) + files(필수) 전송, 응답 type=FILE & files[] 포함
- 기본 채널(General + DEV/DESIGN/MARKETING/PRODUCT)은 서버 기동 시 자동 생성되어 별도 생성 요청 불필요